### PR TITLE
Add basic nuget package creation for metadata + direct deps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Visual Studio 2015
 
 build_script:
-- cmd: msbuild build.proj /t:build,test,package /v:normal 
+- cmd: msbuild build.proj /t:build,test,package /v:minimal 
 
 install:
 - cmd: git submodule update --init --recursive

--- a/src/Build/NuGet.Packaging.Build.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Packaging.Build.Tasks/CreatePackage.cs
@@ -1,5 +1,12 @@
-﻿using Microsoft.Build.Framework;
+﻿using System;
+using System.Linq;
+using System.IO;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Runtime.Versioning;
+using NuGet.Versioning;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging.Build.Tasks
 {
@@ -26,7 +33,7 @@ namespace NuGet.Packaging.Build.Tasks
 
 		public string ProjectUrl { get; set; }
 
-		public string IconUri { get; set; }
+		public string IconUrl { get; set; }
 
 		public string ReleaseNotes { get; set; }
 
@@ -34,23 +41,182 @@ namespace NuGet.Packaging.Build.Tasks
 
 		public string OutputPath { get; set; }
 
-		public string Types { get; set; }
-
-		public bool IsTool { get; set; }
-
-		public string RepositoryUrl { get; set; }
-
-		public string RepositoryType { get; set; }
-
 		public bool NoPackageAnalysis { get; set; }
 
 		public string MinClientVersion { get; set; }
 
-		public ITaskItem[] AssemblyReferences { get; set; }
-
 		public override bool Execute()
 		{
+			//  TODO: create file on OutputPath, invoke ExecuteImpl and return true.
+
 			return true;
+		}
+
+		// Implementation for testing to avoid I/O
+		public Manifest Execute(Stream output)
+		{
+			BuildPackage(output);
+
+			output.Seek(0, SeekOrigin.Begin);
+			var reader = new PackageArchiveReader(output);
+
+			using (var stream = reader.GetNuspec())
+			{
+				return Manifest.ReadFrom(stream, true);
+			}
+		}
+
+		public Manifest CreateManifest()
+		{
+			var metadata = new ManifestMetadata();
+
+			metadata.Id = Id;
+			if (!string.IsNullOrEmpty(Authors))
+				metadata.Authors = Authors.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+			metadata.Description = Description;
+			metadata.Copyright = Copyright;
+			metadata.RequireLicenseAcceptance = string.IsNullOrEmpty(RequireLicenseAcceptance) ? false : bool.Parse(RequireLicenseAcceptance);
+			metadata.SetLicenseUrl(LicenseUrl);
+			metadata.SetProjectUrl(ProjectUrl);
+			metadata.SetIconUrl(IconUrl);
+			metadata.ReleaseNotes = ReleaseNotes;
+			metadata.Tags = Tags;
+			metadata.MinClientVersionString = MinClientVersion;
+			metadata.Version = NuGetVersion.Parse(Version);
+
+			var manifest = new Manifest(metadata);
+
+			// TODO: Add files.
+			AddDependencies(manifest);
+
+			return manifest;
+		}
+
+		void AddDependencies(Manifest manifest)
+		{
+			// Collect all dependencies that are direct on the calling project, 
+			// meaning they have a PackageId == Id being generated.
+			var directDependencies = from item in Contents
+									 where item.GetMetadata(MetadataName.Kind) == PackageFileKind.Dependency
+									 let packageId = item.GetMetadata(MetadataName.PackageId)
+									 where packageId == Id
+									 select new Dependency
+									 {
+										 Id = item.ItemSpec,
+										 Version = VersionRange.Parse(item.GetMetadata(MetadataName.Version)),
+										 TargetFramework = item.GetTargetFramework()
+									 };
+
+			
+			var dependencies = directDependencies; // + add Kind=Metadata as dependencies
+
+			manifest.Metadata.DependencyGroups = (from dependency in dependencies
+												  group dependency by dependency.TargetFramework into dependenciesByFramework
+												  select new PackageDependencyGroup
+												  (
+													  NuGetFramework.Parse(dependenciesByFramework.Key.GetShortFrameworkName() ?? PackagingConstants.AnyFramework),
+													  (from dependency in dependenciesByFramework
+													   where dependency.Id != "_._"
+													   group dependency by dependency.Id into dependenciesById
+													   select new PackageDependency
+													   (
+														  dependenciesById.Key,
+														  dependenciesById.Select(x => x.Version)
+														  .Aggregate(AggregateVersions)
+													   )).ToList()
+												 )).ToList();
+		}
+
+		void BuildPackage(Stream output)
+		{
+			var builder = new PackageBuilder();
+			var manifest = CreateManifest();
+
+			builder.Populate(manifest.Metadata);
+			// We shouldn't need the basePath at this point, since MSBuild will resolve everything to their full paths.
+			builder.PopulateFiles("", manifest.Files);
+
+			builder.Save(output);
+		}
+
+		static VersionRange AggregateVersions(VersionRange aggregate, VersionRange next)
+		{
+			var versionSpec = new VersionSpec();
+			SetMinVersion(versionSpec, aggregate);
+			SetMinVersion(versionSpec, next);
+			SetMaxVersion(versionSpec, aggregate);
+			SetMaxVersion(versionSpec, next);
+
+			if (versionSpec.MinVersion == null && versionSpec.MaxVersion == null)
+				return null;
+
+			return versionSpec.ToVersionRange();
+		}
+
+		static void SetMinVersion(VersionSpec target, VersionRange source)
+		{
+			if (source == null || source.MinVersion == null)
+				return;
+
+			if (target.MinVersion == null)
+			{
+				target.MinVersion = source.MinVersion;
+				target.IsMinInclusive = source.IsMinInclusive;
+			}
+
+			if (target.MinVersion < source.MinVersion)
+			{
+				target.MinVersion = source.MinVersion;
+				target.IsMinInclusive = source.IsMinInclusive;
+			}
+
+			if (target.MinVersion == source.MinVersion)
+				target.IsMinInclusive = target.IsMinInclusive && source.IsMinInclusive;
+		}
+
+		static void SetMaxVersion(VersionSpec target, VersionRange source)
+		{
+			if (source == null || source.MaxVersion == null)
+				return;
+
+			if (target.MaxVersion == null)
+			{
+				target.MaxVersion = source.MaxVersion;
+				target.IsMaxInclusive = source.IsMaxInclusive;
+			}
+
+			if (target.MaxVersion > source.MaxVersion)
+			{
+				target.MaxVersion = source.MaxVersion;
+				target.IsMaxInclusive = source.IsMaxInclusive;
+			}
+
+			if (target.MaxVersion == source.MaxVersion)
+				target.IsMaxInclusive = target.IsMaxInclusive && source.IsMaxInclusive;
+		}
+
+
+		class Dependency
+		{
+			public string Id { get; set; }
+
+			public FrameworkName TargetFramework { get; set; }
+
+			public VersionRange Version { get; set; }
+		}
+
+		class VersionSpec
+		{
+			public bool IsMinInclusive { get; set; }
+			public NuGetVersion MinVersion { get; set; }
+			public bool IsMaxInclusive { get; set; }
+			public NuGetVersion MaxVersion { get; set; }
+
+			public VersionRange ToVersionRange()
+			{
+				return new VersionRange(MinVersion, IsMinInclusive, MaxVersion, IsMaxInclusive);
+			}
 		}
 	}
 }

--- a/src/Build/NuGet.Packaging.Build.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Packaging.Build.Tasks/CreatePackage.cs
@@ -23,7 +23,15 @@ namespace NuGet.Packaging.Build.Tasks
 
 		public string Authors { get; set; }
 
+		public string Owners { get; set; }
+
+		public string Title { get; set; }
+
 		public string Description { get; set; }
+
+		public string Summary { get; set; }
+
+		public string Language { get; set; }
 
 		public string Copyright { get; set; }
 
@@ -73,9 +81,15 @@ namespace NuGet.Packaging.Build.Tasks
 			metadata.Id = Id;
 			if (!string.IsNullOrEmpty(Authors))
 				metadata.Authors = Authors.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+			if (!string.IsNullOrEmpty(Owners))
+				metadata.Owners = Owners.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
+			metadata.Title = Title;
 			metadata.Description = Description;
+			metadata.Summary = Summary;
+			metadata.Language = Language;
 			metadata.Copyright = Copyright;
+
 			metadata.RequireLicenseAcceptance = string.IsNullOrEmpty(RequireLicenseAcceptance) ? false : bool.Parse(RequireLicenseAcceptance);
 			metadata.SetLicenseUrl(LicenseUrl);
 			metadata.SetProjectUrl(ProjectUrl);

--- a/src/Build/NuGet.Packaging.Build.Tasks/Extensions.cs
+++ b/src/Build/NuGet.Packaging.Build.Tasks/Extensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Versioning;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
@@ -8,6 +10,17 @@ namespace NuGet.Packaging.Build.Tasks
 	public static class Extensions
 	{
 		static readonly FrameworkName NullFramework = new FrameworkName("Null,Version=v1.0");
+
+		public static IEnumerable<T> NullAsEmpty<T>(this IEnumerable<T> source) => source ?? Enumerable.Empty<T>();
+
+		public static FrameworkName GetTargetFramework(this ITaskItem taskItem)
+		{
+			var metadataValue = taskItem.GetMetadata(MetadataName.TargetFramework);
+			if (!string.IsNullOrEmpty(metadataValue))
+				return new FrameworkName(NuGetFramework.Parse(metadataValue).DotNetFrameworkName);
+			else
+				return NullFramework;
+		}
 
 		public static FrameworkName GetTargetFrameworkMoniker(this ITaskItem item)
 		{
@@ -30,9 +43,7 @@ namespace NuGet.Packaging.Build.Tasks
 			return NuGetFramework.Parse(frameworkName.FullName).GetShortFolderName();
 		}
 
-		public static void LogErrorCode(this TaskLoggingHelper log, string code, string message, params object[] messageArgs)
-		{
+		public static void LogErrorCode(this TaskLoggingHelper log, string code, string message, params object[] messageArgs) =>
 			log.LogError(string.Empty, code, string.Empty, string.Empty, 0, 0, 0, 0, message, messageArgs);
-		}
 	}
 }

--- a/src/Build/NuGet.Packaging.Build.Tasks/MetadataName.cs
+++ b/src/Build/NuGet.Packaging.Build.Tasks/MetadataName.cs
@@ -6,10 +6,17 @@
 
 		public const string Kind = nameof(Kind);
 
+		public const string Version = nameof(Version);
+
 		/// <summary>
 		/// One of https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs#L27
 		/// </summary>
 		public const string PackageFolder = nameof(PackageFolder);
+
+		/// <summary>
+		/// The package that declares the given package file.
+		/// </summary>
+		public const string PackageId = nameof(PackageId);
 
 		/// <summary>
 		/// Concatenation of <see cref="PackageFolder"/> and <see cref="TargetFramework"/>. 

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.Build.Tasks.csproj
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.Build.Tasks.csproj
@@ -47,5 +47,6 @@
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="NuGet.Packaging.Build.Tasks.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Packaging.Build.targets))\NuGet.Packaging.Build.targets" />
 </Project>

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.Build.Tasks.targets
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.Build.Tasks.targets
@@ -1,0 +1,48 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<PropertyGroup>
+		<CoreCompileDependsOn>
+			PackageFileKind;
+			$(CoreCompileDependsOn);
+		</CoreCompileDependsOn>
+		<PackageKindFile>$(IntermediateOutputPath)PackageKindFile.g$(DefaultLanguageSourceExtension)</PackageKindFile>
+	</PropertyGroup>
+
+	<Target Name="PackageFileKind" BeforeTargets="BuildOnlySettings" DependsOnTargets="GeneratePackageFileKind">
+		<ItemGroup>
+			<Compile Include="$(PackageKindFile)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="GeneratePackageFileKind" Inputs="$(MSBuildThisFileFullPath);NuGet.Packaging.props" Outputs="$(PackageKindFile)">
+		<MakeDir Directories="$(IntermediateOutputPath)" Condition=" !Exists('$(IntermediateOutputPath)') " />
+		<XmlPeek Namespaces="&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;"
+					 Query="/msb:Project/msb:ItemGroup/msb:PackageFileKind/@Include"
+					 XmlInputPath="$(MSBuildThisProjectDirectory)NuGet.Packaging.props">
+			<Output TaskParameter="Result" ItemName="_PackageFileKind" />
+		</XmlPeek>
+
+		<WriteLinesToFile Lines='
+namespace $(RootNamespace)
+{
+	/// &lt;summary&gt;Available Kind metadata for PackageFile items&lt;/summary&gt;
+	public static partial class PackageFileKind
+	{
+' Overwrite='true' File='$(PackageKindFile)' />
+
+		<WriteLinesToFile Lines='				  
+		/// &lt;summary&gt;Kind: %(_PackageFileKind.Identity)&lt;/summary&gt;
+		public const string %(_PackageFileKind.Identity) = "%(_PackageFileKind.Identity)"%3B
+' Overwrite='false' File='$(PackageKindFile)' />
+
+		<WriteLinesToFile Lines='
+	}
+}
+' Overwrite='false' File='$(PackageKindFile)' />
+
+		<ItemGroup>
+			<FileWrites Include="$(PackageKindFile)" />
+		</ItemGroup>
+	</Target>
+
+</Project>

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.props
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.props
@@ -11,42 +11,91 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup>
-        <!-- Default mapping between %(PackageFile.Kind) metadata and package folders inside .nupkg -->
-        <!-- PackageFolder should map to a supported folder as defined in PackagingConstants.Folders -->
-        <!-- The only exception is Dependency -->
-        <PackageFileKind Include="Library">
-            <PackageFolder>lib</PackageFolder>
-        </PackageFileKind>
-        <PackageFileKind Include="Symbols">
-            <PackageFolder>lib</PackageFolder>
-        </PackageFileKind>
-        <PackageFileKind Include="Doc">
-            <PackageFolder>lib</PackageFolder>
-        </PackageFileKind>
-      <PackageFileKind Include="Content">
-        <!-- Plain "content" is deprecated as of NuGet v3+ -->
-        <PackageFolder>contentFiles</PackageFolder>
-      </PackageFileKind>
-      <PackageFileKind Include="None">
-        <!-- Causes the file to end up in the package root dir -->
-        <PackageFolder></PackageFolder>
-      </PackageFileKind>
+	<ItemGroup>
+		<!-- Default mapping between %(PackageFile.Kind) metadata and package folders inside .nupkg -->
+		<!-- PackageFolder should map to a supported folder as defined in PackagingConstants.Folders -->
+		<!-- The exceptions are Dependency, FrameworkReference and AssemblyReference -->
+		<PackageFileKind Include="Library">
+			<PackageFolder>lib</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Symbols">
+			<PackageFolder>lib</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Doc">
+			<PackageFolder>lib</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Content">
+			<!-- Plain "content" is deprecated as of NuGet v3+ -->
+			<PackageFolder>contentFiles</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="None">
+			<!-- Causes the file to end up in the package root dir -->
+			<PackageFolder></PackageFolder>
+		</PackageFileKind>
 
-      <!-- The other valid kinds are: Build, Tools, Content, ContentFiles, Native, Runtime, Ref, Analyzers and Source 
-             We don't need an entry for each since we apply the heuristics of turning the Kind metadata value into pascalCase 
-             and using that as the package folder.
-             We do special-case singular form of the built-in plural form folders.
-        -->
-        <PackageFileKind Include="Tool">
-            <PackageFolder>tools</PackageFolder>
-        </PackageFileKind>
-        <PackageFileKind Include="Runtime">
-            <PackageFolder>runtimes</PackageFolder>
-        </PackageFileKind>
-        <PackageFileKind Include="Analyzer">
-            <PackageFolder>analyzers</PackageFolder>
-        </PackageFileKind>
-    </ItemGroup>
-    
+		<PackageFileKind Include="Build">
+			<PackageFolder>build</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Tools">
+			<PackageFolder>tools</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="ContentFiles">
+			<PackageFolder>contentFiles</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Native">
+			<PackageFolder>native</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Runtimes">
+			<PackageFolder>runtimes</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Ref">
+			<PackageFolder>ref</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Analyzers">
+			<PackageFolder>analyzers</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Source">
+			<PackageFolder>source</PackageFolder>
+		</PackageFileKind>
+
+		<!-- Special-case singular form of the built-in plural form folders. -->
+		<PackageFileKind Include="Tools">
+			<PackageFolder>tools</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Tool">
+			<PackageFolder>tools</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Runtime">
+			<PackageFolder>runtimes</PackageFolder>
+		</PackageFileKind>
+		<PackageFileKind Include="Analyzer">
+			<PackageFolder>analyzers</PackageFolder>
+		</PackageFileKind>
+
+		<!-- For unknown Kind we apply the heuristics of turning the metadata value into pascalCase 
+             and using that as the package folder (i.e. 'Workbooks' -> 'workbooks') -->
+
+		<!-- Finally, specially treated items that we include here for completeness and documentation -->
+
+		<!-- PackageReference items end up as Dependency -->
+		<PackageFileKind Include="Dependency">
+			<PackageFolder></PackageFolder>
+		</PackageFileKind>
+		<!-- Project references that build packages also end up as package dependencies -->
+		<PackageFileKind Include="Metadata">
+			<PackageFolder></PackageFolder>
+		</PackageFileKind>
+
+		<!-- Platform targets could turn @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to FrameworkReference, for example -->
+		<PackageFileKind Include="FrameworkReference">
+			<PackageFolder></PackageFolder>
+		</PackageFileKind>
+
+		<!-- Platform targets cound turn other @(ReferencePath) that are resolved otherwise (i.e. {RawFile}) into AssemblyReference, for example -->
+		<PackageFileKind Include="AssemblyReference">
+			<PackageFolder></PackageFolder>
+		</PackageFileKind>
+
+	</ItemGroup>
+
 </Project>

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.props
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.props
@@ -59,9 +59,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</PackageFileKind>
 
 		<!-- Special-case singular form of the built-in plural form folders. -->
-		<PackageFileKind Include="Tools">
-			<PackageFolder>tools</PackageFolder>
-		</PackageFileKind>
 		<PackageFileKind Include="Tool">
 			<PackageFolder>tools</PackageFolder>
 		</PackageFileKind>

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.targets
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.targets
@@ -21,7 +21,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(IntermediateOutputPath)</PackageOutputPath>
 		<BuildDependsOn Condition="'$(BuildPackage)' == 'true'">
 			$(BuildDependsOn);
-			BuildPackage;
+			Pack;
 		</BuildDependsOn>
 		<!-- NOTE: this is the "internal" DependsOn for our implementation of the collecting target.
 			 Users extend GetPackageContentsDependsOn instead. This ensures that our own dependencies will not 
@@ -52,7 +52,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</PackageFile>
 
 			<PackageFile Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
-							   Condition="'$(IncludeSymbols)' == 'true'">
+						 Condition="'$(IncludeSymbols)' == 'true'">
 				<Kind>Symbols</Kind>
 			</PackageFile>
 
@@ -63,10 +63,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<PackageFile Include="@(PackageReference)">
 				<Kind>Dependency</Kind>
 			</PackageFile>
+			
+			<!-- Specific framework targets would turn:
+				* @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to Kind=FrameworkReference
+				  (maybe ResolvedFrom=ImplicitlyExpandDesignTimeFacades too?)
+				* @(ReferencePath) are resolved otherwise (i.e. ResolvedFrom={RawFile}) to Kind=AssemblyReference
+			-->
 		</ItemGroup>
 
 		<ItemGroup>
-			<!-- Always annotate files with the declaring project target framework -->
+			<!-- Always annotate files with the declaring project target framework. 
+				 TODO: take into account multi-targetting. -->
 			<PackageFile>
 				<PackageId>$(PackageId)</PackageId>
 				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
@@ -121,12 +128,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 	</Target>
 
-	<Target Name="BuildPackage" DependsOnTargets="_CollectPackageContents;$(BuildPackageDependsOn)" Condition="'$(IsPackable)' == 'true'">
-		<ItemGroup>
-			<!-- Ignore references from NuGet packages since they should be package references instead. See _SynthesizePackageReferences above -->
-			<_ReferencePathWithoutPackageId Include="@(ReferencePath -> WithMetadataValue('NuGetPackageId', ''))" />
-		</ItemGroup>
-
+	<Target Name="Pack" DependsOnTargets="_CollectPackageContents;$(BuildPackageDependsOn)" Condition="'$(IsPackable)' == 'true'">
 		<CreatePackage Id="$(PackageId)"
 					   Version="$(PackageVersion)"
 					   Contents="@(PackageContent)"
@@ -140,13 +142,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 					   ReleaseNotes="$(PackageReleaseNotes)"
 					   Tags="$(PackageTags)"
 					   OutputPath="$(PackageOutputPath)"
-					   Types="$(PackageType)"
-					   IsTool="$(IsTool)"
-					   RepositoryUrl="$(RepositoryUrl)"
-					   RepositoryType="$(RepositoryType)"
 					   NoPackageAnalysis="$(NoPackageAnalysis)"
-					   MinClientVersion="$(MinClientVersion)"
-					   AssemblyReferences="@(_ReferencePathWithoutPackageId)"/>
+					   MinClientVersion="$(MinClientVersion)" />
 	</Target>
 
 </Project>

--- a/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.targets
+++ b/src/Build/NuGet.Packaging.Build.Tasks/NuGet.Packaging.targets
@@ -101,9 +101,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<Version>$(PackageVersion)</Version>
 				<Authors>$(Authors)</Authors>
 				<Owners>$(Owners)</Owners>
+				<Title>$(Title)</Title>
 				<Description>$(Description)</Description>
-				<Copyright>$(Copyright)</Copyright>
 				<Summary>$(Summary)</Summary>
+				<Language>$(NeutralLanguage)</Language>
+				<Copyright>$(Copyright)</Copyright>
 
 				<RequireLicenseAcceptance>$(PackageRequireLicenseAcceptance)</RequireLicenseAcceptance>
 				<LicenseUrl>$(PackageLicenseUrl)</LicenseUrl>

--- a/src/Build/NuGet.Packaging.Build.Tests/AssignPackagePathTests.cs
+++ b/src/Build/NuGet.Packaging.Build.Tests/AssignPackagePathTests.cs
@@ -130,12 +130,12 @@ namespace NuGet.Packaging
 			Assert.Equal(expectedTargetFramework, task.AssignedFiles[0].GetMetadata(MetadataName.TargetFramework));
 		}
 
-		public static IEnumerable<object[]> GetKnownKinds => kinds
+		public static IEnumerable<object[]> GetMappedKnownKinds => kinds
 			// None don't get a package folder at all, and contentFiles get a special map that includes the codelang
-			.Where(kind => kind.ItemSpec != "None" && kind.ItemSpec != "Content")
+			.Where(kind => !string.IsNullOrEmpty(kind.GetMetadata(MetadataName.PackageFolder)) && kind.ItemSpec != "Content")
 			.Select(kind => new object[] { kind.ItemSpec, kind.GetMetadata("PackageFolder") });
 
-		[MemberData("GetKnownKinds")]
+		[MemberData("GetMappedKnownKinds")]
 		[Theory]
 		public void when_file_has_known_kind_then_assigned_file_contains_mapped_package_folder(string packageFileKind, string mappedPackageFolder)
 		{

--- a/src/Build/NuGet.Packaging.Build.Tests/AssignPackagePathTests.cs
+++ b/src/Build/NuGet.Packaging.Build.Tests/AssignPackagePathTests.cs
@@ -132,7 +132,7 @@ namespace NuGet.Packaging
 
 		public static IEnumerable<object[]> GetMappedKnownKinds => kinds
 			// None don't get a package folder at all, and contentFiles get a special map that includes the codelang
-			.Where(kind => !string.IsNullOrEmpty(kind.GetMetadata(MetadataName.PackageFolder)) && kind.ItemSpec != "Content")
+			.Where(kind => !string.IsNullOrEmpty(kind.GetMetadata(MetadataName.PackageFolder)) && kind.GetMetadata(MetadataName.PackageFolder) != "contentFiles")
 			.Select(kind => new object[] { kind.ItemSpec, kind.GetMetadata("PackageFolder") });
 
 		[MemberData("GetMappedKnownKinds")]

--- a/src/Build/NuGet.Packaging.Build.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Packaging.Build.Tests/CreatePackageTests.cs
@@ -8,6 +8,11 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Linq;
 using static NuGet.Packaging.Build.Tasks.Properties.Strings;
+using System.Diagnostics;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Metadata = System.Collections.Generic.Dictionary<string, string>;
 
 namespace NuGet.Packaging
 {
@@ -15,11 +20,60 @@ namespace NuGet.Packaging
 	{
 		ITestOutputHelper output;
 		MockBuildEngine engine;
+		CreatePackage task;
+		bool createPackage;
 
 		public CreatePackageTests(ITestOutputHelper output)
 		{
 			this.output = output;
 			engine = new MockBuildEngine(output);
+			task = new CreatePackage
+			{
+				BuildEngine = engine,
+
+				Id = "package",
+				Version = "1.0.0",
+				Description = "description",
+				Authors = "author1, author2",
+			};
+
+#if RELEASE
+			// Create the actual .nupkg to ensure everything is working 
+			// fine end to end.
+			createPackage = true;
+#endif
+
+		}
+
+		Manifest ExecuteTask() => createPackage ?
+				task.Execute(new MemoryStream()) :
+				task.CreateManifest();
+
+		[Fact]
+		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.Kind, PackageFileKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+
+			// We get a version range actually for the specified dependency, like [1.0.0,)
+			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
 		}
 	}
 }

--- a/src/Build/NuGet.Packaging.Build.Tests/NuGet.Packaging.Build.Tests.csproj
+++ b/src/Build/NuGet.Packaging.Build.Tests/NuGet.Packaging.Build.Tests.csproj
@@ -25,7 +25,6 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Scenarios\Scenario.targets" />
-    <None Include="test.proj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />

--- a/src/Build/NuGet.Packaging.Build.sln
+++ b/src/Build/NuGet.Packaging.Build.sln
@@ -6,6 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Packaging.Build.Tasks
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BD16CBB5-BD47-4CC3-A9FD-7F1B9077455D}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\appveyor.yml = ..\..\appveyor.yml
 		..\..\build.cmd = ..\..\build.cmd
 		..\..\build.proj = ..\..\build.proj
 		..\GlobalAssemblyInfo.cs = ..\GlobalAssemblyInfo.cs

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Templates/Spikes/PortableClassLibrary/csPortableClassLibrary.vstemplate
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Templates/Spikes/PortableClassLibrary/csPortableClassLibrary.vstemplate
@@ -29,7 +29,7 @@
     <FullClassName>Microsoft.VisualStudio.PortableLibrary.ProjectFlavoring.Templating.NewProjectTemplateWizardFactory</FullClassName>
   </WizardExtension>
   <WizardExtension>
-    <Assembly>NuGet.Packaging.VisualStudio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5ae9beea16a2da9a</Assembly>
+    <Assembly>NuGet.Packaging.VisualStudio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=44c0b6b1fa7a936a</Assembly>
     <FullClassName>NuGet.Packaging.VisualStudio.NewLibraryWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
Creates a nupkg from the metadata properties and package files
passed in to the CreatePackage task.

Unit test for the basic scenario. Needed to add basic dependency
too because otherwise the package isn't valid.

Partially fixes NuGet/Home#3477
