### PR TITLE
Added package content filtering when packing

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ItemGroup>
 
 		<ItemGroup>
-			<!-- Always annotate files with the declaring project target framework. 
+			<!-- Always annotate files with the declaring project target framework and package id. 
 				 TODO: take into account multi-targetting. -->
 			<PackageFile>
 				<PackageId>$(PackageId)</PackageId>
@@ -70,12 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</PackageFile>
 		</ItemGroup>
 
-		<!-- Ensure we have a TargetPath determined from the current project directory like any other items -->
-		<AssignTargetPath Files="@(PackageFile)" RootFolder="$(MSBuildProjectDirectory)">
-			<Output TaskParameter="AssignedFiles" ItemName="_PackageFileWithTargetPath" />
-		</AssignTargetPath>
-
-		<AssignPackagePath Files="@(_PackageFileWithTargetPath)" Kinds="@(PackageItemKind)">
+		<AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)">
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
 
@@ -84,20 +79,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<_PackageContent Include="@(PackageReference)">
 				<Kind>Dependency</Kind>
 			</_PackageContent>
+
 			<!-- Specific framework targets would turn:
 				* @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to Kind=FrameworkReference
 				  (maybe ResolvedFrom=ImplicitlyExpandDesignTimeFacades too?)
 				* @(ReferencePath) are resolved otherwise (i.e. ResolvedFrom={RawFile}) to Kind=AssemblyReference
 			-->
 		</ItemGroup>
-		
+
 		<!-- If packaging the project, provide the metadata as a non-file item -->
 		<ItemGroup Condition="'$(PackageId)' != ''">
 			<_PackageContent Include="$(PackageId)">
-				<!-- For consistency with the other items, we also provide this metadata -->
-				<PackageId>$(PackageId)</PackageId>
 				<Kind>Metadata</Kind>
-
+				
 				<!-- The rest of the metadata items don't need to repeat "Package" prefix all the time -->
 				<Id>$(PackageId)</Id>
 				<Version>$(PackageVersion)</Version>
@@ -112,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<RequireLicenseAcceptance>$(PackageRequireLicenseAcceptance)</RequireLicenseAcceptance>
 				<LicenseUrl>$(PackageLicenseUrl)</LicenseUrl>
 				<ProjectUrl>$(PackageProjectUrl)</ProjectUrl>
+				<IconUrl>$(PackageIconUrl)</IconUrl>
 				<Tags>$(PackageTags)</Tags>
 
 				<ReleaseNotes>$(PackageReleaseNotes)</ReleaseNotes>
@@ -121,33 +116,111 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</_PackageContent>
 		</ItemGroup>
 
+		<ItemGroup>
+			<!-- Ensure our content items have both metadata values -->
+			<_PackageContent>
+				<PackageId>$(PackageId)</PackageId>
+				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</_PackageContent>
+		</ItemGroup>
+
 		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
 				 Targets="GetPackageContents"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
 				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
 				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_PackageContent" />
+			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedPackageContent" />
 		</MSBuild>
+
+		<!-- Always annotate package contents with the declaring project target framework and package id -->
+		<ItemGroup>
+			<_ReferencedPackageContent Condition="'%(_ReferencedPackageContent.PackageId)' == ''">
+				<!-- We preserve whatever package id the item had -->
+				<PackageId>$(PackageId)</PackageId>
+				<!-- NOTE: we're always overwriting the TFM in this case since 
+					 this item will end up making up the contents of this package 
+					 project in its current TFM configuration. 
+					 TBD: we might want to preserve it anyways and adjust later 
+					 (i.e. net45 project references netstandard1.6 project)
+					 TODO: take into account multi-targetting.
+				-->
+				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</_ReferencedPackageContent>
+		</ItemGroup>
+
+		<!-- Ensure referenced package content gets assigned a package path if it didn't provide one already.
+			 This happens for project references' that don't have a PackageId, since their package path will 
+			 depend on the referencing project's TFM.
+		-->
+		<AssignPackagePath Files="@(_ReferencedPackageContent)" Kinds="@(PackageItemKind)">
+			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
+		</AssignPackagePath>
 
 	</Target>
 
-	<Target Name="Pack" DependsOnTargets="_CollectPackageContents;$(BuildPackageDependsOn)" Condition="'$(IsPackable)' == 'true'">
+	<Target Name="Pack" DependsOnTargets="GetPackageContents;$(PackDependsOn);_FilterPackageDependencyContents" Condition="'$(IsPackable)' == 'true'">
+		<!-- RepositoryUrl/RepositoryType/PackageType to be added -->
 		<CreatePackage Id="$(PackageId)"
 					   Version="$(PackageVersion)"
-					   Contents="@(PackageContent)"
+					   Contents="@(_FilteredPackageContent)"
 					   Authors="$(Authors)"
+					   Owners="$(Owners)"
+					   Title="$(Title)"
 					   Description="$(Description)"
+					   Summary="$(Summary)"
+					   Language="$(NeutralLanguage)"
 					   Copyright="$(Copyright)"
+					   
 					   RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
 					   LicenseUrl="$(PackageLicenseUrl)"
 					   ProjectUrl="$(PackageProjectUrl)"
 					   IconUrl="$(PackageIconUrl)"
-					   ReleaseNotes="$(PackageReleaseNotes)"
 					   Tags="$(PackageTags)"
-					   OutputPath="$(PackageOutputPath)"
-					   NoPackageAnalysis="$(NoPackageAnalysis)"
-					   MinClientVersion="$(MinClientVersion)" />
+
+					   ReleaseNotes="$(PackageReleaseNotes)"
+					   MinClientVersion="$(MinClientVersion)"
+					   
+					   OutputPath="$(PackageOutputPath)" />
+	</Target>
+
+	<!-- This target's purpose is to remove from _PackageContent the items that are the contents of 
+		 indirect package dependencies that transitive project references build, turning those into 
+		 just a Dependency item for Pack.
+		 The Outputs="%(PackageId)-BATCH" groups the @(_PackageContent) into batches coming from the same 
+		 package for easier processing. The '-BATCH' ensures we also process the batch without a PackageId.
+	-->
+	<Target Name="_FilterPackageDependencyContents" DependsOnTargets="GetPackageContents" Inputs="@(_PackageContent)" Outputs="%(PackageId)-BATCH" Returns="@(_FilteredPackageContent)">
+		<ItemGroup>
+			<!-- Attempt to grab a manifest for the current batch -->
+			<_DependencyManifest Include="@(_PackageContent)" Condition="'%(Kind)' == 'Metadata'" />
+		</ItemGroup>
+		<PropertyGroup>
+			<!-- Determine up-front if this batch belongs to the package being built.
+				 We do this by checking for empty %(MSBuildSourceProjectFile), since 
+				 that metadata is assigned for project references we execute GetPackageContents on.
+			-->
+			<IsSelfContent>@(_PackageContent -> AnyHaveMetadataValue("MSBuildSourceProjectFile", ""))</IsSelfContent>
+			<!-- If the group has a metadata item, then it's all part of a package dependency -->
+			<IsDependencyContent Condition="'$(IsSelfContent)' != 'true' And '@(_DependencyManifest)' != ''">true</IsDependencyContent>
+			<!-- Grab the dependency source project in this case, to use it right after -->
+			<DependencySourceProject Condition="'$(IsDependencyContent)' == 'true'">@(_DependencyManifest -> '%(MSBuildSourceProjectFile)')</DependencySourceProject>
+			<!-- Lookup the dependency project in the list of referenced MSBuild projects to detect a direct dependency -->
+			<IsDirectDependency Condition="'$(IsDependencyContent)' == 'true'">@(_MSBuildProjectReferenceExistent -> AnyHaveMetadataValue("FullPath", "$(DependencySourceProject)"))</IsDirectDependency>
+		</PropertyGroup>
+
+		<ItemGroup Condition="'$(IsDependencyContent)' == 'true'">
+			<!-- Only keep the package dependency if it's a direct project reference. 
+				 We don't need the transitive packages for pack -->
+			<_FilteredPackageContent Include="@(_DependencyManifest)" Condition="'$(IsDirectDependency)' == 'true'">
+				<!-- Change its kind to Dependency. It will already contain the Version metadata for further processing -->
+				<Kind>Dependency</Kind>
+			</_FilteredPackageContent>
+		</ItemGroup>
+		<ItemGroup Condition="'$(IsDependencyContent)' != 'true'">
+			<!-- Otherwise, bring it all in since there is no package to depend on -->
+			<_FilteredPackageContent Include="@(_PackageContent)" />
+		</ItemGroup>
 	</Target>
 
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
@@ -42,6 +42,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
 					})
 				}
@@ -62,11 +63,13 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("a.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Lib" }
 					}),
 					new TaskItem("a.pdb", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Symbols" }
 					})
@@ -76,6 +79,69 @@ namespace NuGet.Build.Packaging
 			Assert.True(task.Execute());
 
 			Assert.Equal(task.Files.Length, task.AssignedFiles.Length);
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_package_path_is_not_specified()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("", task.AssignedFiles[0].GetMetadata(MetadataName.PackagePath));
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_target_framework_is_calculated_anyway()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("net45", task.AssignedFiles[0].GetMetadata(MetadataName.TargetFramework));
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_package_folder_is_calculated_anyway()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("lib", task.AssignedFiles[0].GetMetadata(MetadataName.PackageFolder));
 		}
 
 		[Fact]
@@ -89,6 +155,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "Kind", "Lib" }
 					})
 				}
@@ -118,6 +185,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", targetFrameworkMoniker },
 						{ "Kind", "Lib" }
 					})
@@ -147,6 +215,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", packageFileKind }
 					})
@@ -169,6 +238,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("readme.txt", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" },
 						{ "PackagePath", "docs\\readme.txt" }
@@ -196,6 +266,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("Sample.cs", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", tfm },
 						{ "Kind", "Content" },
 						{ "CodeLanguage", lang }
@@ -220,6 +291,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("readme.txt", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" }
 					})
@@ -242,6 +314,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" },
 						{ "TargetPath", "workbook\\library.dll"}
@@ -265,6 +338,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" }
 					})
@@ -289,6 +363,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", packageFileKind }
 					})
@@ -311,6 +386,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "Kind", "Tool" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}
 					})
@@ -332,6 +408,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Tool" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
@@ -14,13 +14,21 @@ using Xunit.Sdk;
 /// </summary>
 static partial class Builder
 {
-	public static ITargetResult BuildScenario(string scenarioName, object properties = null, string target = "GetPackageContents", ITestOutputHelper output = null, LoggerVerbosity? verbosity = null)
+	public static ITargetResult BuildScenario(string scenarioName, object properties = null, string projectName = null, string target = "GetPackageContents", ITestOutputHelper output = null, LoggerVerbosity? verbosity = null)
 	{
-		var projectName = scenarioName;
-		if (scenarioName.StartsWith("given", StringComparison.OrdinalIgnoreCase))
-			projectName = string.Join("_", scenarioName.Split('_').Skip(2));
-
 		var scenarioDir = Path.Combine(ModuleInitializer.BaseDirectory, "Scenarios", scenarioName);
+
+		if (projectName == null)
+		{
+			projectName = scenarioName;
+			if (scenarioName.StartsWith("given", StringComparison.OrdinalIgnoreCase))
+				projectName = string.Join("_", scenarioName.Split('_').Skip(2));
+		}
+		else if (!File.Exists(Path.Combine(scenarioDir, $"{projectName}.csproj")))
+		{
+			throw new FileNotFoundException($"Project '{projectName}' was not found under scenario path '{scenarioDir}'.", projectName);
+		}
+
 		string projectOrSolution;
 
 		if (File.Exists(Path.Combine(scenarioDir, $"{projectName}.csproj")))

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -65,33 +65,6 @@ namespace NuGet.Build.Packaging
 				task.CreateManifest();
 
 		[Fact]
-		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
-		{
-			task.Contents = new[]
-			{
-				new TaskItem("Newtonsoft.Json", new Metadata
-				{
-					{ MetadataName.PackageId, task.Id },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
-					{ MetadataName.Version, "8.0.0" },
-					// NOTE: AssignPackagePath takes care of converting TFM > short name
-					{ MetadataName.TargetFramework, "net45" }
-				}),
-			};
-
-			var manifest = ExecuteTask();
-
-			Assert.NotNull(manifest);
-			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
-			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
-			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
-			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
-
-			// We get a version range actually for the specified dependency, like [1.0.0,)
-			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
-		}
-
-		[Fact]
 		public void when_creating_package_then_contains_all_metadata()
 		{
 			task.Contents = new[]
@@ -121,6 +94,62 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(task.IconUrl, metadata.IconUrl.ToString());
 			Assert.Equal(task.ReleaseNotes, metadata.ReleaseNotes);
 			Assert.Equal(task.MinClientVersion, metadata.MinClientVersion.ToString());
+		}
+
+
+		[Fact]
+		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+
+			// We get a version range actually for the specified dependency, like [1.0.0,)
+			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
+		}
+
+
+		[Fact]
+		public void when_creating_package_with_referenced_package_project_then_contains_package_dependency()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+
+			// We get a version range actually for the specified dependency, like [1.0.0,)
+			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -18,6 +18,15 @@
     <None Include="NuGet.Build.Packaging.Tests.targets">
       <SubType>Designer</SubType>
     </None>
+    <Content Include="Scenarios\given_a_complex_pack\a.csproj">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Scenarios\given_a_complex_pack\b.csproj">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Scenarios\given_a_complex_pack\c.csproj" />
+    <Content Include="Scenarios\given_a_complex_pack\d.csproj" />
+    <Content Include="Scenarios\given_a_complex_pack\e.csproj" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.json" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.lock.json" />
     <None Include="Scenarios\Scenario.props">
@@ -50,11 +59,13 @@
     <Compile Include="Builder.NuGetizer.cs">
       <DependentUpon>Builder.cs</DependentUpon>
     </Compile>
+    <Compile Include="given_a_complex_pack.cs" />
     <Compile Include="given_library_project_with_nugets.cs" />
     <Compile Include="given_an_empty_library_project.cs" />
     <Compile Include="given_a_library_with_project_reference.cs" />
     <Compile Include="Utilities\MockBuildEngine.cs" />
     <Compile Include="Utilities\ModuleInitializer.cs" />
+    <Compile Include="Utilities\TaskItemExtensions.cs" />
     <Compile Include="Utilities\TestOutputLogger.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
@@ -9,7 +9,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Tests.nuget.targets))\NuGet.Build.Packaging.Tests.nuget.targets"/>
 	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.targets" />
 
-	<PropertyGroup>
+	<!--<PropertyGroup>
 		<GetPackageContentsDependsOn>
 			AddPackageFile;
 			$(GetPackageContentsDependsOn);
@@ -20,15 +20,24 @@
 		<ItemGroup>
 			<PackageFile Include="readme.txt">
 				<Kind>Content</Kind>
-				<CodeLanguage>cs</CodeLanguage>
+				<CodeLanguage>any</CodeLanguage>
+				<TargetFramework>any</TargetFramework>
 			</PackageFile>
 		</ItemGroup>
+	</Target>-->
+
+	<Target Name="Dump" DependsOnTargets="_FilterPackageDependencyContents">
+		<!--<DumpItems Items="@(_FilteredPackageContent)" ItemName="_FilteredPackageContent" />-->
+		<!--<DumpItems Items="@(_MSBuildProjectReferenceExistent)" ItemName="_MSBuildProjectReferenceExistent" />-->
+		<Message Importance="high" Text="%(_FilteredPackageContent.Filename)%(_FilteredPackageContent.Extension)
+	Kind=%(_FilteredPackageContent.Kind)
+	PackageId=%(_FilteredPackageContent.PackageId)
+	PackagePath=%(_FilteredPackageContent.PackagePath)
+	TargetFramework=%(_FilteredPackageContent.TargetFramework)
+	TargetFrameworkMoniker=%(_FilteredPackageContent.TargetFrameworkMoniker)" />
 	</Target>
 
-	<Target Name="Dump" DependsOnTargets="GetPackageContents">
-		<DumpItems Items="@(_PackageContent)" ItemName="_PackageContent" />
-	</Target>
-
+	
 	<!-- Turn off Fody we use for ModuleInitializer in unit tests -->
 	<Target Name="FodyTarget" />
 	<Target Name="FodyVerifyTarget" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>A</PackageId>
+		<PackageVersion>1.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="b.csproj">
+			<Project>$(GuidB)</Project>
+			<Name>b</Name>
+		</ProjectReference>
+		<ProjectReference Include="e.csproj">
+			<Project>$(GuidE)</Project>
+			<Name>e</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidB)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>B</PackageId>
+		<PackageVersion>2.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="c.csproj">
+			<Project>$(GuidC)</Project>
+			<Name>c</Name>
+		</ProjectReference>
+		<ProjectReference Include="d.csproj">
+			<Project>$(GuidD)</Project>
+			<Name>d</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidC)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>C</PackageId>
+		<PackageVersion>3.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Foo">
+			<Version>1.0.0</Version>
+		</PackageReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidD)</ProjectGuid>
+		<TargetFrameworkMoniker>.NETPortable,Version=v5.0</TargetFrameworkMoniker>
+		<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+	</PropertyGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidE)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	</PropertyGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace NuGet.Build.Packaging
+{
+	public static class TaskItemExtensions
+	{
+		/// <summary>
+		/// Checks if the given item has metadata key/values matching the 
+		/// anonymous object property/values.
+		/// </summary>
+		public static bool Matches(this ITaskItem item, object metadata)
+		{
+			foreach (var prop in metadata.GetType().GetProperties())
+			{
+				var actual = item.GetMetadata(prop.Name);
+				var expected = prop.GetValue(metadata).ToString();
+
+				if (actual != expected)
+					return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
@@ -1,0 +1,150 @@
+﻿using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using NuGet.Build.Packaging.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Build.Packaging
+{
+	public class given_a_complex_pack
+	{
+		ITestOutputHelper output;
+
+		public given_a_complex_pack(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public void when_packing_a_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\a.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\a.xml",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\e.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\e.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "A",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "B",
+					Version = "2.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_b_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\b.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\b.xml",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\d.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\d.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "B",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "C",
+					Version = "3.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_c_then_contains_external_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\c.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\c.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "C",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "Foo",
+					Version = "1.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_d_without_package_id_then_does_not_set_package_path()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "d", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					Filename = "d",
+					Extension = ".dll",
+					Kind = "Lib",
+					PackagePath = "",
+				}),
+				item => item.Matches(new
+				{
+					Filename = "d",
+					Extension = ".xml",
+					Kind = "Lib",
+					PackagePath = "",
+				})
+			);
+		}
+	}
+}


### PR DESCRIPTION
The following behavior is implemented:
- Direct dependency PackageContent is turned into a single Dependency
- Direct non-package project references are properly assigned package path

One specific test covering direct and indirect dependencies, package
and regular project references was added too.
