### PR TITLE
Added package content filtering when packing

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -49,7 +49,7 @@
 			<XunitOptions>$(XunitOptions) -html $(Out)\test.html -xml $(Out)\test.xml -parallel none -noshadow</XunitOptions>
 
 			<CoverageConsole>$(PackagesPath)\OpenCover\tools\OpenCover.Console.exe</CoverageConsole>
-			<CoverageOptions>$(CoverageOptions) -output:$(Out)\coverage.xml -returntargetcode -register:user -filter:"+[NuGet.Build.Packaging*]* -[NuGet.Packaging.VisualStudio*]* -[Clide*]* -[xunit*]* -[*Tests]* -[*]*ThisAssembly*" -excludebyattribute:*ExcludeFromCodeCoverage*;*CompilerGenerated* -skipautoprops -showunvisited -mergebyhash</CoverageOptions>
+			<CoverageOptions>$(CoverageOptions) -output:$(Out)\coverage.xml -returntargetcode -register:user -filter:"+[NuGet.Build.Packaging*]* -[NuGet.Packaging.Core*]* -[NuGet.Packaging.VisualStudio*]* -[Clide*]* -[xunit*]* -[*Tests]* -[*]*ThisAssembly*" -excludebyattribute:*ExcludeFromCodeCoverage*;*CompilerGenerated* -skipautoprops -showunvisited -mergebyhash</CoverageOptions>
 			<CoverageCommand>$(CoverageConsole) $(CoverageOptions) -target:$(XunitConsole) -targetargs:"@(TestAssembly, ' ') $(XunitOptions)"</CoverageCommand>
 
 			<ReportConsole>$(PackagesPath)\ReportGenerator\tools\ReportGenerator.exe</ReportConsole>

--- a/src/Build/NuGet.Build.Packaging.Tasks/AssignPackagePath.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/AssignPackagePath.cs
@@ -71,7 +71,10 @@ namespace NuGet.Build.Packaging.Tasks
 			// If PackagePath already specified, skip the rest.
 			if (!string.IsNullOrEmpty(file.GetMetadata("PackagePath")) ||
 				// TBD: If no PackageId specified, we'll let referencing projects define the package path 
-				string.IsNullOrEmpty(file.GetMetadata("PackageId")))
+				string.IsNullOrEmpty(file.GetMetadata("PackageId")) || 
+				// If the kind is known but there is no mapped folder into the package, skip the rest.
+				// Special-case None kind since that means 'leave it wherever it lands' ;)
+				(string.IsNullOrEmpty(packageFolder) && kind != PackageItemKind.None))
 				return output;
 
 			// Special case for contentFiles, since they can also provide a codeLanguage metadata
@@ -89,6 +92,9 @@ namespace NuGet.Build.Packaging.Tasks
 					targetFramework = PackagingConstants.AnyFramework;
 			}
 
+			// NOTE: TargetPath allows a framework-specific file to still specify its relative 
+			// location without hardcoding the target framework (useful for multi-targetting and 
+			// P2P references)
 			var targetPath = file.GetMetadata("TargetPath");
 			if (string.IsNullOrEmpty(targetPath))
 				targetPath = file.GetMetadata("FileName") + file.GetMetadata("Extension");

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ItemGroup>
 
 		<ItemGroup>
-			<!-- Always annotate files with the declaring project target framework. 
+			<!-- Always annotate files with the declaring project target framework and package id. 
 				 TODO: take into account multi-targetting. -->
 			<PackageFile>
 				<PackageId>$(PackageId)</PackageId>
@@ -70,12 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</PackageFile>
 		</ItemGroup>
 
-		<!-- Ensure we have a TargetPath determined from the current project directory like any other items -->
-		<AssignTargetPath Files="@(PackageFile)" RootFolder="$(MSBuildProjectDirectory)">
-			<Output TaskParameter="AssignedFiles" ItemName="_PackageFileWithTargetPath" />
-		</AssignTargetPath>
-
-		<AssignPackagePath Files="@(_PackageFileWithTargetPath)" Kinds="@(PackageItemKind)">
+		<AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)">
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
 
@@ -84,20 +79,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<_PackageContent Include="@(PackageReference)">
 				<Kind>Dependency</Kind>
 			</_PackageContent>
+
 			<!-- Specific framework targets would turn:
 				* @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to Kind=FrameworkReference
 				  (maybe ResolvedFrom=ImplicitlyExpandDesignTimeFacades too?)
 				* @(ReferencePath) are resolved otherwise (i.e. ResolvedFrom={RawFile}) to Kind=AssemblyReference
 			-->
 		</ItemGroup>
-		
+
 		<!-- If packaging the project, provide the metadata as a non-file item -->
 		<ItemGroup Condition="'$(PackageId)' != ''">
 			<_PackageContent Include="$(PackageId)">
-				<!-- For consistency with the other items, we also provide this metadata -->
-				<PackageId>$(PackageId)</PackageId>
 				<Kind>Metadata</Kind>
-
+				
 				<!-- The rest of the metadata items don't need to repeat "Package" prefix all the time -->
 				<Id>$(PackageId)</Id>
 				<Version>$(PackageVersion)</Version>
@@ -112,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<RequireLicenseAcceptance>$(PackageRequireLicenseAcceptance)</RequireLicenseAcceptance>
 				<LicenseUrl>$(PackageLicenseUrl)</LicenseUrl>
 				<ProjectUrl>$(PackageProjectUrl)</ProjectUrl>
+				<IconUrl>$(PackageIconUrl)</IconUrl>
 				<Tags>$(PackageTags)</Tags>
 
 				<ReleaseNotes>$(PackageReleaseNotes)</ReleaseNotes>
@@ -121,33 +116,111 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</_PackageContent>
 		</ItemGroup>
 
+		<ItemGroup>
+			<!-- Ensure our content items have both metadata values -->
+			<_PackageContent>
+				<PackageId>$(PackageId)</PackageId>
+				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</_PackageContent>
+		</ItemGroup>
+
 		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
 				 Targets="GetPackageContents"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
 				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
 				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_PackageContent" />
+			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedPackageContent" />
 		</MSBuild>
+
+		<!-- Always annotate package contents with the declaring project target framework and package id -->
+		<ItemGroup>
+			<_ReferencedPackageContent Condition="'%(_ReferencedPackageContent.PackageId)' == ''">
+				<!-- We preserve whatever package id the item had -->
+				<PackageId>$(PackageId)</PackageId>
+				<!-- NOTE: we're always overwriting the TFM in this case since 
+					 this item will end up making up the contents of this package 
+					 project in its current TFM configuration. 
+					 TBD: we might want to preserve it anyways and adjust later 
+					 (i.e. net45 project references netstandard1.6 project)
+					 TODO: take into account multi-targetting.
+				-->
+				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</_ReferencedPackageContent>
+		</ItemGroup>
+
+		<!-- Ensure referenced package content gets assigned a package path if it didn't provide one already.
+			 This happens for project references' that don't have a PackageId, since their package path will 
+			 depend on the referencing project's TFM.
+		-->
+		<AssignPackagePath Files="@(_ReferencedPackageContent)" Kinds="@(PackageItemKind)">
+			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
+		</AssignPackagePath>
 
 	</Target>
 
-	<Target Name="Pack" DependsOnTargets="_CollectPackageContents;$(BuildPackageDependsOn)" Condition="'$(IsPackable)' == 'true'">
+	<Target Name="Pack" DependsOnTargets="GetPackageContents;$(PackDependsOn);_FilterPackageDependencyContents" Condition="'$(IsPackable)' == 'true'">
+		<!-- RepositoryUrl/RepositoryType/PackageType to be added -->
 		<CreatePackage Id="$(PackageId)"
 					   Version="$(PackageVersion)"
-					   Contents="@(PackageContent)"
+					   Contents="@(_FilteredPackageContent)"
 					   Authors="$(Authors)"
+					   Owners="$(Owners)"
+					   Title="$(Title)"
 					   Description="$(Description)"
+					   Summary="$(Summary)"
+					   Language="$(NeutralLanguage)"
 					   Copyright="$(Copyright)"
+					   
 					   RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
 					   LicenseUrl="$(PackageLicenseUrl)"
 					   ProjectUrl="$(PackageProjectUrl)"
 					   IconUrl="$(PackageIconUrl)"
-					   ReleaseNotes="$(PackageReleaseNotes)"
 					   Tags="$(PackageTags)"
-					   OutputPath="$(PackageOutputPath)"
-					   NoPackageAnalysis="$(NoPackageAnalysis)"
-					   MinClientVersion="$(MinClientVersion)" />
+
+					   ReleaseNotes="$(PackageReleaseNotes)"
+					   MinClientVersion="$(MinClientVersion)"
+					   
+					   OutputPath="$(PackageOutputPath)" />
+	</Target>
+
+	<!-- This target's purpose is to remove from _PackageContent the items that are the contents of 
+		 indirect package dependencies that transitive project references build, turning those into 
+		 just a Dependency item for Pack.
+		 The Outputs="%(PackageId)-BATCH" groups the @(_PackageContent) into batches coming from the same 
+		 package for easier processing. The '-BATCH' ensures we also process the batch without a PackageId.
+	-->
+	<Target Name="_FilterPackageDependencyContents" DependsOnTargets="GetPackageContents" Inputs="@(_PackageContent)" Outputs="%(PackageId)-BATCH" Returns="@(_FilteredPackageContent)">
+		<ItemGroup>
+			<!-- Attempt to grab a manifest for the current batch -->
+			<_DependencyManifest Include="@(_PackageContent)" Condition="'%(Kind)' == 'Metadata'" />
+		</ItemGroup>
+		<PropertyGroup>
+			<!-- Determine up-front if this batch belongs to the package being built.
+				 We do this by checking for empty %(MSBuildSourceProjectFile), since 
+				 that metadata is assigned for project references we execute GetPackageContents on.
+			-->
+			<IsSelfContent>@(_PackageContent -> AnyHaveMetadataValue("MSBuildSourceProjectFile", ""))</IsSelfContent>
+			<!-- If the group has a metadata item, then it's all part of a package dependency -->
+			<IsDependencyContent Condition="'$(IsSelfContent)' != 'true' And '@(_DependencyManifest)' != ''">true</IsDependencyContent>
+			<!-- Grab the dependency source project in this case, to use it right after -->
+			<DependencySourceProject Condition="'$(IsDependencyContent)' == 'true'">@(_DependencyManifest -> '%(MSBuildSourceProjectFile)')</DependencySourceProject>
+			<!-- Lookup the dependency project in the list of referenced MSBuild projects to detect a direct dependency -->
+			<IsDirectDependency Condition="'$(IsDependencyContent)' == 'true'">@(_MSBuildProjectReferenceExistent -> AnyHaveMetadataValue("FullPath", "$(DependencySourceProject)"))</IsDirectDependency>
+		</PropertyGroup>
+
+		<ItemGroup Condition="'$(IsDependencyContent)' == 'true'">
+			<!-- Only keep the package dependency if it's a direct project reference. 
+				 We don't need the transitive packages for pack -->
+			<_FilteredPackageContent Include="@(_DependencyManifest)" Condition="'$(IsDirectDependency)' == 'true'">
+				<!-- Change its kind to Dependency. It will already contain the Version metadata for further processing -->
+				<Kind>Dependency</Kind>
+			</_FilteredPackageContent>
+		</ItemGroup>
+		<ItemGroup Condition="'$(IsDependencyContent)' != 'true'">
+			<!-- Otherwise, bring it all in since there is no package to depend on -->
+			<_FilteredPackageContent Include="@(_PackageContent)" />
+		</ItemGroup>
 	</Target>
 
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -15,11 +15,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 	<PropertyGroup>
 		<IncludeSymbols Condition=" '$(IncludeSymbols)' == '' and '$(Configuration)' == 'Debug' ">true</IncludeSymbols>
-		<IsPackable Condition="'$(IsPackable)' == '' And '$(PackageId)' != ''">true</IsPackable>
-		<BuildPackage Condition=" '$(BuildPackage)' == '' and '$(IsPackable)' == 'true'">true</BuildPackage>
-		<!-- Directory where the .nupkg will be saved to if BuildPackage is run -->
-		<PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(IntermediateOutputPath)</PackageOutputPath>
-		<BuildDependsOn Condition="'$(BuildPackage)' == 'true'">
+		<IsPackable Condition="'$(IsPackable)' == '' and '$(PackageId)' != ''">true</IsPackable>
+		<!-- Directory where the .nupkg will be saved to if Pack is run -->
+		<PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(OutputPath)</PackageOutputPath>
+		<BuildDependsOn Condition="'$(PackOnBuild)' == 'true' and '$(IsPackable)' == 'true'">
 			$(BuildDependsOn);
 			Pack;
 		</BuildDependsOn>
@@ -31,21 +30,32 @@ Copyright (c) .NET Foundation. All rights reserved.
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
 			AllProjectOutputGroups;
+			GetPackageVersion;
 			_CollectPackageContents;
 		</_GetPackageContentsDependsOn>
 	</PropertyGroup>
 
 	<Target Name="GetPackageContents" DependsOnTargets="$(_GetPackageContentsDependsOn)" Returns="@(_PackageContent)" />
 
-	<Target Name="_CollectPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)">
-		<!-- We define these here so that potentially other targets can populate these properties before this target runs. -->
+	<!-- Redefine or provide a PackageVersion to override the default. -->
+	<Target Name="GetPackageVersion"  Condition="'$(PackageVersion)' == ''">
 		<PropertyGroup>
 			<PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
 		</PropertyGroup>
+	</Target>
 
+	<!-- Redefine or provide a PackageVersion to override the default. -->
+	<Target Name="GetPackageTargetPath" DependsOnTargets="GetPackageVersion" Returns="$(PackageTargetPath)">
+		<PropertyGroup>
+			<PackageTargetPath Condition="'$(PackageTargetPath)' == '' and '$(PackageId)' != ''">$([System.IO.Path]::Combine('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))</PackageTargetPath>
+      <PackageTargetPath Condition="'$(PackageTargetPath)' != ''">$([System.IO.Path]::GetFullPath('$(PackageTargetPath)'))</PackageTargetPath>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_CollectPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)">
 		<!-- PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
-         NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the 
-         current project. -->
+			 NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
+			 current project. -->
 		<ItemGroup>
 			<PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
 				<Kind>Lib</Kind>
@@ -59,7 +69,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<PackageFile Include="@(DocumentationProjectOutputGroupOutput -> '%(FinalOutputPath)')">
 				<Kind>Doc</Kind>
 			</PackageFile>
-		</ItemGroup>
+
+      <PackageFile Include="@(PackageReference)">
+        <Kind>Dependency</Kind>
+      </PackageFile>
+    </ItemGroup>
 
 		<ItemGroup>
 			<!-- Always annotate files with the declaring project target framework and package id. 
@@ -75,11 +89,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</AssignPackagePath>
 
 		<ItemGroup>
-			<!-- Convert PackageReferences to _PackageContent -->
-			<_PackageContent Include="@(PackageReference)">
-				<Kind>Dependency</Kind>
-			</_PackageContent>
-
 			<!-- Specific framework targets would turn:
 				* @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to Kind=FrameworkReference
 				  (maybe ResolvedFrom=ImplicitlyExpandDesignTimeFacades too?)
@@ -91,8 +100,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup Condition="'$(PackageId)' != ''">
 			<_PackageContent Include="$(PackageId)">
 				<Kind>Metadata</Kind>
-				
-				<!-- The rest of the metadata items don't need to repeat "Package" prefix all the time -->
+        <PackageId>$(PackageId)</PackageId>
+        <TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+
+        <!-- The rest of the metadata items don't need to repeat "Package" prefix all the time -->
 				<Id>$(PackageId)</Id>
 				<Version>$(PackageVersion)</Version>
 				<Authors>$(Authors)</Authors>
@@ -113,14 +124,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
 				<RepositoryType>$(RepositoryType)</RepositoryType>
 				<PackageType>$(PackageType)</PackageType>
-			</_PackageContent>
-		</ItemGroup>
-
-		<ItemGroup>
-			<!-- Ensure our content items have both metadata values -->
-			<_PackageContent>
-				<PackageId>$(PackageId)</PackageId>
-				<TargetFrameworkMoniker>$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
 			</_PackageContent>
 		</ItemGroup>
 
@@ -153,44 +156,44 @@ Copyright (c) .NET Foundation. All rights reserved.
 			 This happens for project references' that don't have a PackageId, since their package path will 
 			 depend on the referencing project's TFM.
 		-->
-		<AssignPackagePath Files="@(_ReferencedPackageContent)" Kinds="@(PackageItemKind)">
+		<AssignPackagePath Files="@(_ReferencedPackageContent)" Kinds="@(PackageItemKind)" Condition="'@(_ReferencedPackageContent)' != ''">
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
 
 	</Target>
 
-	<Target Name="Pack" DependsOnTargets="GetPackageContents;$(PackDependsOn);_FilterPackageDependencyContents" Condition="'$(IsPackable)' == 'true'">
+	<PropertyGroup>
+		<_PackDependsOn>
+			CoreBuild;
+			GetPackageContents;
+			GetPackageVersion;
+			GetPackageTargetPath;
+			_PrepareForPack;
+			_Pack;
+		</_PackDependsOn>
+	</PropertyGroup>
+
+	<Target Name="Pack" DependsOnTargets="$(_PackDependsOn)" Returns="@(PackageTargetPath)" Condition="'$(IsPackable)' == 'true'" />
+
+	<Target Name="_Pack" DependsOnTargets="$(PackDependsOn)" Returns="@(PackageTargetPath)">
+    <ItemGroup>
+      <_PackageManifest Include="@(_PackContent -> WithMetadataValue('Kind', 'Metadata'))" Condition="'%(PackageId)' == '$(PackageId)'" />
+    </ItemGroup>
 		<!-- RepositoryUrl/RepositoryType/PackageType to be added -->
-		<CreatePackage Id="$(PackageId)"
-					   Version="$(PackageVersion)"
-					   Contents="@(_FilteredPackageContent)"
-					   Authors="$(Authors)"
-					   Owners="$(Owners)"
-					   Title="$(Title)"
-					   Description="$(Description)"
-					   Summary="$(Summary)"
-					   Language="$(NeutralLanguage)"
-					   Copyright="$(Copyright)"
-					   
-					   RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
-					   LicenseUrl="$(PackageLicenseUrl)"
-					   ProjectUrl="$(PackageProjectUrl)"
-					   IconUrl="$(PackageIconUrl)"
-					   Tags="$(PackageTags)"
+    <CreatePackage Manifest="@(_PackageManifest)" Contents="@(_PackContent)" TargetPath="$(PackageTargetPath)">
+      <Output TaskParameter="OutputPackage" ItemName="PackageTargetPath" />
+    </CreatePackage>
 
-					   ReleaseNotes="$(PackageReleaseNotes)"
-					   MinClientVersion="$(MinClientVersion)"
-					   
-					   OutputPath="$(PackageOutputPath)" />
+		<Message Importance="normal" Text="Created package at $(PackageTargetPath)." />
 	</Target>
-
+	
 	<!-- This target's purpose is to remove from _PackageContent the items that are the contents of 
 		 indirect package dependencies that transitive project references build, turning those into 
 		 just a Dependency item for Pack.
 		 The Outputs="%(PackageId)-BATCH" groups the @(_PackageContent) into batches coming from the same 
 		 package for easier processing. The '-BATCH' ensures we also process the batch without a PackageId.
 	-->
-	<Target Name="_FilterPackageDependencyContents" DependsOnTargets="GetPackageContents" Inputs="@(_PackageContent)" Outputs="%(PackageId)-BATCH" Returns="@(_FilteredPackageContent)">
+	<Target Name="_PrepareForPack" DependsOnTargets="GetPackageContents" Inputs="@(_PackageContent)" Outputs="%(PackageId)-BATCH" Returns="@(_PackContent)">
 		<ItemGroup>
 			<!-- Attempt to grab a manifest for the current batch -->
 			<_DependencyManifest Include="@(_PackageContent)" Condition="'%(Kind)' == 'Metadata'" />
@@ -202,7 +205,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			-->
 			<IsSelfContent>@(_PackageContent -> AnyHaveMetadataValue("MSBuildSourceProjectFile", ""))</IsSelfContent>
 			<!-- If the group has a metadata item, then it's all part of a package dependency -->
-			<IsDependencyContent Condition="'$(IsSelfContent)' != 'true' And '@(_DependencyManifest)' != ''">true</IsDependencyContent>
+			<IsDependencyContent Condition="'$(IsSelfContent)' != 'true' and '@(_DependencyManifest)' != ''">true</IsDependencyContent>
 			<!-- Grab the dependency source project in this case, to use it right after -->
 			<DependencySourceProject Condition="'$(IsDependencyContent)' == 'true'">@(_DependencyManifest -> '%(MSBuildSourceProjectFile)')</DependencySourceProject>
 			<!-- Lookup the dependency project in the list of referenced MSBuild projects to detect a direct dependency -->
@@ -212,14 +215,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup Condition="'$(IsDependencyContent)' == 'true'">
 			<!-- Only keep the package dependency if it's a direct project reference. 
 				 We don't need the transitive packages for pack -->
-			<_FilteredPackageContent Include="@(_DependencyManifest)" Condition="'$(IsDirectDependency)' == 'true'">
+			<_PackContent Include="@(_DependencyManifest)" Condition="'$(IsDirectDependency)' == 'true'">
 				<!-- Change its kind to Dependency. It will already contain the Version metadata for further processing -->
 				<Kind>Dependency</Kind>
-			</_FilteredPackageContent>
+			</_PackContent>
 		</ItemGroup>
 		<ItemGroup Condition="'$(IsDependencyContent)' != 'true'">
 			<!-- Otherwise, bring it all in since there is no package to depend on -->
-			<_FilteredPackageContent Include="@(_PackageContent)" />
+			<_PackContent Include="@(_PackageContent)" />
 		</ItemGroup>
 	</Target>
 

--- a/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
@@ -42,6 +42,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
 					})
 				}
@@ -62,11 +63,13 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("a.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Lib" }
 					}),
 					new TaskItem("a.pdb", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Symbols" }
 					})
@@ -76,6 +79,69 @@ namespace NuGet.Build.Packaging
 			Assert.True(task.Execute());
 
 			Assert.Equal(task.Files.Length, task.AssignedFiles.Length);
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_package_path_is_not_specified()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("", task.AssignedFiles[0].GetMetadata(MetadataName.PackagePath));
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_target_framework_is_calculated_anyway()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("net45", task.AssignedFiles[0].GetMetadata(MetadataName.TargetFramework));
+		}
+
+		[Fact]
+		public void when_file_has_no_package_id_then_package_folder_is_calculated_anyway()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("library.dll", new Dictionary<string,string>
+					{
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Lib" }
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+			Assert.Equal("lib", task.AssignedFiles[0].GetMetadata(MetadataName.PackageFolder));
 		}
 
 		[Fact]
@@ -89,6 +155,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "Kind", "Lib" }
 					})
 				}
@@ -118,6 +185,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", targetFrameworkMoniker },
 						{ "Kind", "Lib" }
 					})
@@ -147,6 +215,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", packageFileKind }
 					})
@@ -169,6 +238,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("readme.txt", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" },
 						{ "PackagePath", "docs\\readme.txt" }
@@ -196,6 +266,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("Sample.cs", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", tfm },
 						{ "Kind", "Content" },
 						{ "CodeLanguage", lang }
@@ -220,6 +291,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("readme.txt", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" }
 					})
@@ -242,6 +314,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" },
 						{ "TargetPath", "workbook\\library.dll"}
@@ -265,6 +338,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "None" }
 					})
@@ -289,6 +363,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("library.dll", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", packageFileKind }
 					})
@@ -311,6 +386,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "Kind", "Tool" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}
 					})
@@ -332,6 +408,7 @@ namespace NuGet.Build.Packaging
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Dictionary<string,string>
 					{
+						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "Kind", "Tool" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
@@ -14,13 +14,21 @@ using Xunit.Sdk;
 /// </summary>
 static partial class Builder
 {
-	public static ITargetResult BuildScenario(string scenarioName, object properties = null, string target = "GetPackageContents", ITestOutputHelper output = null, LoggerVerbosity? verbosity = null)
+	public static ITargetResult BuildScenario(string scenarioName, object properties = null, string projectName = null, string target = "GetPackageContents", ITestOutputHelper output = null, LoggerVerbosity? verbosity = null)
 	{
-		var projectName = scenarioName;
-		if (scenarioName.StartsWith("given", StringComparison.OrdinalIgnoreCase))
-			projectName = string.Join("_", scenarioName.Split('_').Skip(2));
-
 		var scenarioDir = Path.Combine(ModuleInitializer.BaseDirectory, "Scenarios", scenarioName);
+
+		if (projectName == null)
+		{
+			projectName = scenarioName;
+			if (scenarioName.StartsWith("given", StringComparison.OrdinalIgnoreCase))
+				projectName = string.Join("_", scenarioName.Split('_').Skip(2));
+		}
+		else if (!File.Exists(Path.Combine(scenarioDir, $"{projectName}.csproj")))
+		{
+			throw new FileNotFoundException($"Project '{projectName}' was not found under scenario path '{scenarioDir}'.", projectName);
+		}
+
 		string projectOrSolution;
 
 		if (File.Exists(Path.Combine(scenarioDir, $"{projectName}.csproj")))

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -74,20 +75,26 @@ public class VerbosityAttribute : BeforeAfterTestAttribute
 
 	public override void Before(MethodInfo methodUnderTest)
 	{
+		// Don't ever set the verbosity on release builds just in case 
+		// we forget the attribute in a commit ;)
+#if DEBUG
 		var data = Thread.GetNamedDataSlot(nameof(LoggerVerbosity));
 		if (data == null)
 			data = Thread.AllocateNamedDataSlot(nameof(LoggerVerbosity));
 
 		Thread.SetData(data, Verbosity);
+#endif
 
 		base.Before(methodUnderTest);
 	}
 
 	public override void After(MethodInfo methodUnderTest)
 	{
+#if DEBUG
 		var data = Thread.GetNamedDataSlot(nameof(LoggerVerbosity));
 		if (data != null)
 			Thread.SetData(data, null);
+#endif
 
 		base.After(methodUnderTest);
 	}

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.cs
@@ -67,7 +67,7 @@ public static partial class Builder
 			xml.Add(new XElement("ProjectConfiguration",
 				new XAttribute("Project", reference.GetPropertyValue("ProjectGuid")),
 				new XAttribute("AbsolutePath", reference.FullPath),
-				new XAttribute("BuildProjectInSolution", "false"))
+				new XAttribute("BuildProjectInSolution", "true"))
 			{
 				Value = $"{config}|{platform}"
 			});

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -31,26 +31,28 @@ namespace NuGet.Build.Packaging
 			task = new CreatePackage
 			{
 				BuildEngine = engine,
+				Manifest = new TaskItem("package", new Metadata
+				{
+					{ "Id", "package" },
+					{ "Version", "1.0.0" },
+					{ "Title", "title" },
+					{ "Description", "description" },
+					{ "Summary", "summary" },
+					{ "Language", "en" },
 
-				Id = "package",
-				Version = "1.0.0",
-				Title = "title",
-				Description = "description",
-				Summary = "summary",
-				Language = "en",
+					{ "Copyright", "copyright" },
+					{ "RequireLicenseAcceptance", "true" },
 
-				Copyright = "copyright",
-				RequireLicenseAcceptance = "true",
+					{ "Authors", "author1, author2" },
+					{ "Owners", "owner1, owner2" },
+					{ "Tags", "nuget msbuild" },
 
-				Authors = "author1, author2",
-				Owners = "owner1, owner2",
-				Tags = "nuget msbuild",
-
-				LicenseUrl = "http://contoso.com/license.txt", 
-				ProjectUrl = "http://contoso.com/",
-				IconUrl = "http://contoso.com/icon.png",
-				ReleaseNotes = "release notes",
-				MinClientVersion = "3.4.0",
+					{ "LicenseUrl", "http://contoso.com/license.txt" },
+					{ "ProjectUrl", "http://contoso.com/" },
+					{ "IconUrl", "http://contoso.com/icon.png" },
+					{ "ReleaseNotes", "release notes" },
+					{ "MinClientVersion", "3.4.0" },
+				})
 			};
 
 #if RELEASE
@@ -72,7 +74,7 @@ namespace NuGet.Build.Packaging
 				// Need at least one dependency or content file for the generation to succeed.
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
-					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.Kind, PackageItemKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
@@ -81,21 +83,21 @@ namespace NuGet.Build.Packaging
 
 			var metadata = ExecuteTask().Metadata;
 
-			Assert.Equal(task.Id, metadata.Id);
-			Assert.Equal(task.Version, metadata.Version.ToString());
-			Assert.Equal(task.Title, metadata.Title);
-			Assert.Equal(task.Description, metadata.Description);
-			Assert.Equal(task.Summary, metadata.Summary);
-			Assert.Equal(task.Language, metadata.Language);
-			Assert.Equal(task.Copyright, metadata.Copyright);
 			Assert.True(metadata.RequireLicenseAcceptance);
-			Assert.Equal(task.LicenseUrl, metadata.LicenseUrl.ToString());
-			Assert.Equal(task.ProjectUrl, metadata.ProjectUrl.ToString());
-			Assert.Equal(task.IconUrl, metadata.IconUrl.ToString());
-			Assert.Equal(task.ReleaseNotes, metadata.ReleaseNotes);
-			Assert.Equal(task.MinClientVersion, metadata.MinClientVersion.ToString());
-		}
 
+			Assert.Equal(task.Manifest.GetMetadata("Id"), metadata.Id);
+			Assert.Equal(task.Manifest.GetMetadata("Version"), metadata.Version.ToString());
+			Assert.Equal(task.Manifest.GetMetadata("Title"), metadata.Title);
+			Assert.Equal(task.Manifest.GetMetadata("Description"), metadata.Description);
+			Assert.Equal(task.Manifest.GetMetadata("Summary"), metadata.Summary);
+			Assert.Equal(task.Manifest.GetMetadata("Language"), metadata.Language);
+			Assert.Equal(task.Manifest.GetMetadata("Copyright"), metadata.Copyright);
+			Assert.Equal(task.Manifest.GetMetadata("LicenseUrl"), metadata.LicenseUrl.ToString());
+			Assert.Equal(task.Manifest.GetMetadata("ProjectUrl"), metadata.ProjectUrl.ToString());
+			Assert.Equal(task.Manifest.GetMetadata("IconUrl"), metadata.IconUrl.ToString());
+			Assert.Equal(task.Manifest.GetMetadata("ReleaseNotes"), metadata.ReleaseNotes);
+			Assert.Equal(task.Manifest.GetMetadata("MinClientVersion"), metadata.MinClientVersion.ToString());
+		}
 
 		[Fact]
 		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
@@ -104,7 +106,7 @@ namespace NuGet.Build.Packaging
 			{
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
-					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.Kind, PackageItemKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
@@ -124,7 +126,6 @@ namespace NuGet.Build.Packaging
 			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
 		}
 
-
 		[Fact]
 		public void when_creating_package_with_referenced_package_project_then_contains_package_dependency()
 		{
@@ -132,7 +133,7 @@ namespace NuGet.Build.Packaging
 			{
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
-					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.Kind, PackageItemKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
@@ -150,6 +151,26 @@ namespace NuGet.Build.Packaging
 
 			// We get a version range actually for the specified dependency, like [1.0.0,)
 			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
+		}
+
+		[Fact]
+		public void when_creating_package_with_file_then_contains_file()
+		{
+			var content = Path.GetTempFileName();
+			task.Contents = new[]
+			{
+				new TaskItem(content, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackagePath, "readme.txt" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Contains(manifest.Files, file => file.Target == "readme.txt");
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -65,33 +65,6 @@ namespace NuGet.Build.Packaging
 				task.CreateManifest();
 
 		[Fact]
-		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
-		{
-			task.Contents = new[]
-			{
-				new TaskItem("Newtonsoft.Json", new Metadata
-				{
-					{ MetadataName.PackageId, task.Id },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
-					{ MetadataName.Version, "8.0.0" },
-					// NOTE: AssignPackagePath takes care of converting TFM > short name
-					{ MetadataName.TargetFramework, "net45" }
-				}),
-			};
-
-			var manifest = ExecuteTask();
-
-			Assert.NotNull(manifest);
-			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
-			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
-			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
-			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
-
-			// We get a version range actually for the specified dependency, like [1.0.0,)
-			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
-		}
-
-		[Fact]
 		public void when_creating_package_then_contains_all_metadata()
 		{
 			task.Contents = new[]
@@ -121,6 +94,62 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(task.IconUrl, metadata.IconUrl.ToString());
 			Assert.Equal(task.ReleaseNotes, metadata.ReleaseNotes);
 			Assert.Equal(task.MinClientVersion, metadata.MinClientVersion.ToString());
+		}
+
+
+		[Fact]
+		public void when_creating_package_with_simple_dependency_then_contains_dependency_group()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+
+			// We get a version range actually for the specified dependency, like [1.0.0,)
+			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
+		}
+
+
+		[Fact]
+		public void when_creating_package_with_referenced_package_project_then_contains_package_dependency()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Id },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+
+			// We get a version range actually for the specified dependency, like [1.0.0,)
+			Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -18,6 +18,15 @@
     <None Include="NuGet.Build.Packaging.Tests.targets">
       <SubType>Designer</SubType>
     </None>
+    <Content Include="Scenarios\given_a_complex_pack\a.csproj">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Scenarios\given_a_complex_pack\b.csproj">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Scenarios\given_a_complex_pack\c.csproj" />
+    <Content Include="Scenarios\given_a_complex_pack\d.csproj" />
+    <Content Include="Scenarios\given_a_complex_pack\e.csproj" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.json" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.lock.json" />
     <None Include="Scenarios\Scenario.props">
@@ -50,11 +59,13 @@
     <Compile Include="Builder.NuGetizer.cs">
       <DependentUpon>Builder.cs</DependentUpon>
     </Compile>
+    <Compile Include="given_a_complex_pack.cs" />
     <Compile Include="given_library_project_with_nugets.cs" />
     <Compile Include="given_an_empty_library_project.cs" />
     <Compile Include="given_a_library_with_project_reference.cs" />
     <Compile Include="Utilities\MockBuildEngine.cs" />
     <Compile Include="Utilities\ModuleInitializer.cs" />
+    <Compile Include="Utilities\TaskItemExtensions.cs" />
     <Compile Include="Utilities\TestOutputLogger.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -63,16 +65,13 @@
     <Compile Include="given_library_project_with_nugets.cs" />
     <Compile Include="given_an_empty_library_project.cs" />
     <Compile Include="given_a_library_with_project_reference.cs" />
+    <Compile Include="UtilitiesTests.cs" />
     <Compile Include="Utilities\MockBuildEngine.cs" />
     <Compile Include="Utilities\ModuleInitializer.cs" />
     <Compile Include="Utilities\TaskItemExtensions.cs" />
     <Compile Include="Utilities\TestOutputLogger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NuGet.Build.Packaging.Authoring.Tasks\NuGet.Build.Packaging.Authoring.Tasks.csproj">
-      <Project>{f145ce58-06aa-4499-89d5-e5144b38d8f3}</Project>
-      <Name>NuGet.Build.Packaging.Authoring.Tasks</Name>
-    </ProjectReference>
     <ProjectReference Include="..\NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj">
       <Project>{a3d231d7-31e4-4a70-8cd1-7246c7d069f6}</Project>
       <Name>NuGet.Build.Packaging.Tasks</Name>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.props
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.props
@@ -11,6 +11,7 @@
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
 		<OutputPath>bin\$(MSBuildProjectName)</OutputPath>
+		<IntermediateOutputPath>obj\$(MSBuildProjectName)</IntermediateOutputPath>
 		<OutputType>Library</OutputType>
 		<RootNamespace>Scenario</RootNamespace>
 		<!-- These properties are more likely to change per-project -->
@@ -29,11 +30,20 @@
 
 		<!-- Used for Dump/Introspect -->
 		<UseCompiledTasks>true</UseCompiledTasks>
+		
 		<!-- Avoids warnings from Xamarin global imports.-->
 		<!--<ImportByWildcardAfterMicrosoftCommonTargets>false</ImportByWildcardAfterMicrosoftCommonTargets>
 		<ImportByWildcardBeforeMicrosoftCommonTargets>false</ImportByWildcardBeforeMicrosoftCommonTargets>-->
 		<!-- Prevents Fody.VerifyTask from running -->
 		<NCrunch>1</NCrunch>
+		<!-- Avoids architecture mismatch warnings -->
+		<ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<!-- Required package metadata -->
+		<Authors>NuGet</Authors>
+		<Description>Package for '$(MSBuildProjectName)' project.</Description>
 	</PropertyGroup>
 
 	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.props" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
@@ -9,7 +9,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Tests.nuget.targets))\NuGet.Build.Packaging.Tests.nuget.targets"/>
 	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.targets" />
 
-	<PropertyGroup>
+	<!--<PropertyGroup>
 		<GetPackageContentsDependsOn>
 			AddPackageFile;
 			$(GetPackageContentsDependsOn);
@@ -20,15 +20,24 @@
 		<ItemGroup>
 			<PackageFile Include="readme.txt">
 				<Kind>Content</Kind>
-				<CodeLanguage>cs</CodeLanguage>
+				<CodeLanguage>any</CodeLanguage>
+				<TargetFramework>any</TargetFramework>
 			</PackageFile>
 		</ItemGroup>
+	</Target>-->
+
+	<Target Name="Dump" DependsOnTargets="_FilterPackageDependencyContents">
+		<!--<DumpItems Items="@(_FilteredPackageContent)" ItemName="_FilteredPackageContent" />-->
+		<!--<DumpItems Items="@(_MSBuildProjectReferenceExistent)" ItemName="_MSBuildProjectReferenceExistent" />-->
+		<Message Importance="high" Text="%(_FilteredPackageContent.Filename)%(_FilteredPackageContent.Extension)
+	Kind=%(_FilteredPackageContent.Kind)
+	PackageId=%(_FilteredPackageContent.PackageId)
+	PackagePath=%(_FilteredPackageContent.PackagePath)
+	TargetFramework=%(_FilteredPackageContent.TargetFramework)
+	TargetFrameworkMoniker=%(_FilteredPackageContent.TargetFrameworkMoniker)" />
 	</Target>
 
-	<Target Name="Dump" DependsOnTargets="GetPackageContents">
-		<DumpItems Items="@(_PackageContent)" ItemName="_PackageContent" />
-	</Target>
-
+	
 	<!-- Turn off Fody we use for ModuleInitializer in unit tests -->
 	<Target Name="FodyTarget" />
 	<Target Name="FodyVerifyTarget" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
@@ -26,15 +26,16 @@
 		</ItemGroup>
 	</Target>-->
 
-	<Target Name="Dump" DependsOnTargets="_FilterPackageDependencyContents">
-		<!--<DumpItems Items="@(_FilteredPackageContent)" ItemName="_FilteredPackageContent" />-->
-		<!--<DumpItems Items="@(_MSBuildProjectReferenceExistent)" ItemName="_MSBuildProjectReferenceExistent" />-->
-		<Message Importance="high" Text="%(_FilteredPackageContent.Filename)%(_FilteredPackageContent.Extension)
-	Kind=%(_FilteredPackageContent.Kind)
-	PackageId=%(_FilteredPackageContent.PackageId)
-	PackagePath=%(_FilteredPackageContent.PackagePath)
-	TargetFramework=%(_FilteredPackageContent.TargetFramework)
-	TargetFrameworkMoniker=%(_FilteredPackageContent.TargetFrameworkMoniker)" />
+	<Target Name="Dump" DependsOnTargets="GetPackageContents">
+    <DumpItems Items="@(_PackageContent)" ItemName="_PackageContent" />
+    <!--<DumpItems Items="@(_MSBuildProjectReferenceExistent)" ItemName="_MSBuildProjectReferenceExistent" />-->
+		<Message Importance="high" Text="%(_PackContent.Filename)%(_PackContent.Extension)
+	Kind=%(_PackContent.Kind)
+	PackageId=%(_PackContent.PackageId)
+	PackagePath=%(_PackContent.PackagePath)
+	TargetFramework=%(_PackContent.TargetFramework)
+	TargetFrameworkMoniker=%(_PackContent.TargetFrameworkMoniker)" />
+
 	</Target>
 
 	

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>A</PackageId>
+		<PackageVersion>1.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="b.csproj">
+			<Project>$(GuidB)</Project>
+			<Name>b</Name>
+		</ProjectReference>
+		<ProjectReference Include="e.csproj">
+			<Project>$(GuidE)</Project>
+			<Name>e</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/a.csproj
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
 	<PropertyGroup>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ProjectGuid>$(GuidA)</ProjectGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 		<PackageId>A</PackageId>
 		<PackageVersion>1.0.0</PackageVersion>
 	</PropertyGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
 	<PropertyGroup>
 		<ProjectGuid>$(GuidB)</ProjectGuid>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/b.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidB)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>B</PackageId>
+		<PackageVersion>2.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="c.csproj">
+			<Project>$(GuidC)</Project>
+			<Name>c</Name>
+		</ProjectReference>
+		<ProjectReference Include="d.csproj">
+			<Project>$(GuidD)</Project>
+			<Name>d</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
 	<PropertyGroup>
 		<ProjectGuid>$(GuidC)</ProjectGuid>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/c.csproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidC)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<PackageId>C</PackageId>
+		<PackageVersion>3.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Foo">
+			<Version>1.0.0</Version>
+		</PackageReference>
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidD)</ProjectGuid>
+		<TargetFrameworkMoniker>.NETPortable,Version=v5.0</TargetFrameworkMoniker>
+		<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+	</PropertyGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/d.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
 	<PropertyGroup>
 		<ProjectGuid>$(GuidD)</ProjectGuid>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
 	<PropertyGroup>
 		<ProjectGuid>$(GuidE)</ProjectGuid>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/e.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidE)</ProjectGuid>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	</PropertyGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/pack.sln
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_complex_pack/pack.sln
@@ -1,0 +1,35 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "a", "a.csproj", "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "b", "b.csproj", "{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "c", "c.csproj", "{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "d", "d.csproj", "{DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "e", "e.csproj", "{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace NuGet.Build.Packaging
+{
+	public static class TaskItemExtensions
+	{
+		/// <summary>
+		/// Checks if the given item has metadata key/values matching the 
+		/// anonymous object property/values.
+		/// </summary>
+		public static bool Matches(this ITaskItem item, object metadata)
+		{
+			foreach (var prop in metadata.GetType().GetProperties())
+			{
+				var actual = item.GetMetadata(prop.Name);
+				var expected = prop.GetValue(metadata).ToString();
+
+				if (actual != expected)
+					return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/TaskItemExtensions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
+using NuGet.Packaging;
+using Xunit;
 
 namespace NuGet.Build.Packaging
 {
@@ -25,6 +27,14 @@ namespace NuGet.Build.Packaging
 			}
 
 			return true;
+		}
+
+		public static Manifest GetManifest(this ITaskItem package)
+		{
+			using (var reader = new PackageArchiveReader(package.GetMetadata("FullPath")))
+			{
+				return reader.GetManifest();
+			}
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/UtilitiesTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/UtilitiesTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Utilities;
+using NuGet.Build.Packaging.Tasks;
+using NuGet.Frameworks;
+using Xunit;
+using Metadata = System.Collections.Generic.Dictionary<string, string>;
+
+namespace NuGet.Build.Packaging
+{
+	public class UtilitiesTests
+	{
+		[Fact]
+		public void when_getting_target_framework_then_fallback_to_tfm()
+		{
+			var item = new TaskItem("Foo", new Metadata
+			{
+				{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
+			});
+
+			var framework = item.GetTargetFramework();
+
+			Assert.Equal(new FrameworkName(".NETFramework,Version=v4.5"), framework);
+		}
+
+		[Fact]
+		public void when_getting_target_framework_then_does_not_use_tfm()
+		{
+			var item = new TaskItem("Foo", new Metadata
+			{
+				{ "TargetFramework", "net46" },
+				{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
+			});
+
+			var framework = item.GetTargetFramework();
+
+			Assert.Equal(new FrameworkName(".NETFramework,Version=v4.6"), framework);
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
@@ -1,0 +1,150 @@
+﻿using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using NuGet.Build.Packaging.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Build.Packaging
+{
+	public class given_a_complex_pack
+	{
+		ITestOutputHelper output;
+
+		public given_a_complex_pack(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public void when_packing_a_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\a.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\a.xml",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\e.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\e.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "A",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "B",
+					Version = "2.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_b_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\b.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\b.xml",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\d.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\d.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "B",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "C",
+					Version = "3.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_c_then_contains_external_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\c.dll",
+				}),
+				item => item.Matches(new
+				{
+					PackagePath = @"lib\net45\c.xml",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Metadata",
+					Filename = "C",
+				}),
+				item => item.Matches(new
+				{
+					Kind = "Dependency",
+					PackageId = "Foo",
+					Version = "1.0.0",
+				})
+			);
+		}
+
+		[Fact]
+		public void when_packing_d_without_package_id_then_does_not_set_package_path()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "d", target: "_FilterPackageDependencyContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Collection(result.Items,
+				item => item.Matches(new
+				{
+					Filename = "d",
+					Extension = ".dll",
+					Kind = "Lib",
+					PackagePath = "",
+				}),
+				item => item.Matches(new
+				{
+					Filename = "d",
+					Extension = ".xml",
+					Kind = "Lib",
+					PackagePath = "",
+				})
+			);
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
@@ -2,6 +2,8 @@
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using NuGet.Build.Packaging.Tasks;
+using NuGet.Frameworks;
+using NuGet.Packaging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,134 +19,189 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
-		public void when_packing_a_then_contains_assemblies_and_direct_dependency()
+		public void when_preparing_a_then_contains_assemblies_and_direct_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "_FilterPackageDependencyContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "_PrepareForPack", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
-			Assert.Collection(result.Items,
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\a.dll",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\a.xml",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\e.dll",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\e.xml",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Metadata",
-					Filename = "A",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Dependency",
-					PackageId = "B",
-					Version = "2.0.0",
-				})
-			);
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\a.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\a.xml",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\e.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\e.xml",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Metadata",
+				Filename = "A",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Dependency",
+				PackageId = "B",
+				Version = "2.0.0",
+			}));
+		}
+
+		[Fact]
+		public void when_preparing_b_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "_PrepareForPack", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\b.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\b.xml",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\d.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\d.xml",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Metadata",
+				Filename = "B",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Dependency",
+				PackageId = "C",
+				Version = "3.0.0",
+			}));
+		}
+
+		[Fact]
+		public void when_preparing_c_then_contains_external_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "_PrepareForPack", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\c.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net45\c.xml",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Metadata",
+				Filename = "C",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Identity = "Foo",
+				Kind = "Dependency",
+				Version = "1.0.0",
+			}));
+		}
+
+		[Fact]
+		public void when_preparing_d_without_package_id_then_does_not_set_package_path()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "d", target: "_PrepareForPack", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Filename = "d",
+				Extension = ".dll",
+				Kind = "Lib",
+				PackagePath = "",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Filename = "d",
+				Extension = ".xml",
+				Kind = "Doc",
+				PackagePath = "",
+			}));
+		}
+
+		[Fact]
+		public void when_packing_a_then_contains_assemblies_and_direct_dependency()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "a", target: "Pack", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			var manifest = result.Items[0].GetManifest();
+
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\a.dll");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\a.xml");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\e.dll");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\e.xml");
+
+			Assert.Contains(manifest.Metadata.DependencyGroups, group =>
+				group.TargetFramework.Equals(NuGetFramework.Parse("net45")) &&
+				group.Packages.Any(dep => dep.Id == "B" && dep.VersionRange.OriginalString == "2.0.0"));
 		}
 
 		[Fact]
 		public void when_packing_b_then_contains_assemblies_and_direct_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "_FilterPackageDependencyContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "b", target: "Pack", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
-			Assert.Collection(result.Items,
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\b.dll",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\b.xml",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\d.dll",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\d.xml",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Metadata",
-					Filename = "B",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Dependency",
-					PackageId = "C",
-					Version = "3.0.0",
-				})
-			);
+			var manifest = result.Items[0].GetManifest();
+
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\b.dll");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\b.xml");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\d.dll");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\d.xml");
+
+			Assert.Contains(manifest.Metadata.DependencyGroups, group =>
+				group.TargetFramework.Equals(NuGetFramework.Parse("net45")) &&
+				group.Packages.Any(dep => dep.Id == "C" && dep.VersionRange.OriginalString == "3.0.0"));
 		}
 
 		[Fact]
 		public void when_packing_c_then_contains_external_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "_FilterPackageDependencyContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "c", target: "Pack", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
-			Assert.Collection(result.Items,
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\c.dll",
-				}),
-				item => item.Matches(new
-				{
-					PackagePath = @"lib\net45\c.xml",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Metadata",
-					Filename = "C",
-				}),
-				item => item.Matches(new
-				{
-					Kind = "Dependency",
-					PackageId = "Foo",
-					Version = "1.0.0",
-				})
-			);
+			var manifest = result.Items[0].GetManifest();
+
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\c.dll");
+			Assert.Contains(manifest.Files, file => file.Target == @"lib\net45\c.xml");
+
+			Assert.Contains(manifest.Metadata.DependencyGroups, group =>
+				group.TargetFramework.Equals(NuGetFramework.Parse("net45")) &&
+				group.Packages.Any(dep => dep.Id == "Foo" && dep.VersionRange.OriginalString == "1.0.0"));
 		}
 
 		[Fact]
-		public void when_packing_d_without_package_id_then_does_not_set_package_path()
+		public void when_packing_d_without_package_id_then_target_is_skipped()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "d", target: "_FilterPackageDependencyContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "d", target: "Pack", output: output);
 
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.Collection(result.Items,
-				item => item.Matches(new
-				{
-					Filename = "d",
-					Extension = ".dll",
-					Kind = "Lib",
-					PackagePath = "",
-				}),
-				item => item.Matches(new
-				{
-					Filename = "d",
-					Extension = ".xml",
-					Kind = "Lib",
-					PackagePath = "",
-				})
-			);
+			Assert.Equal(TargetResultCode.Skipped, result.ResultCode);
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
@@ -34,6 +34,7 @@ namespace NuGet.Build.Packaging
 			Assert.True(result.Items.Any(i => i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == "Symbols"), "Did not include main symbols");
 		}
 
+		[Verbosity(Microsoft.Build.Framework.LoggerVerbosity.Diagnostic)]
 		[Fact]
 		public void when_getting_package_contents_then_annotates_items_with_package_id()
 		{

--- a/src/NuGet.Build.Packaging.Shared.props
+++ b/src/NuGet.Build.Packaging.Shared.props
@@ -25,13 +25,17 @@
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>full</DebugType>
 		<NoWarn>1692;$(NoWarn)</NoWarn>
-		<SignAssembly>true</SignAssembly>
-		<PublicSign>true</PublicSign>
-		<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
 		<ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
 		<ThisAssemblyNamespace>$(RootNamespace)</ThisAssemblyNamespace>
 	</PropertyGroup>
 
+	<!-- Default to unsigned assemblies unless explicitly told to sign -->
+	<PropertyGroup Condition="'$(PublicSign)' == 'true'">
+		<SignAssembly>true</SignAssembly>
+		<PublicSign>true</PublicSign>
+		<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+	
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DefineConstants Condition=" '$(DefineConstants)' != '' ">$(DefineConstants);RELEASE</DefineConstants>
 		<DefineConstants Condition=" '$(DefineConstants)' == '' ">RELEASE</DefineConstants>


### PR DESCRIPTION
The following behavior is implemented:
- Direct dependency PackageContent is turned into a single Dependency
- Direct non-package project references are properly assigned package path
- Libs added to the right places inside the .nupkg
- Packing an entire solution via /p:PackOnBuild=true

Code coverage from tests at 80+% 😃. You can get the number by running `msbuild /t:coverage` on the repo root.
