### PR TITLE
Fail the build if a referenced project isn't nugetized

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
@@ -25,6 +25,11 @@
 		/// </summary>
 		public const string PackagePath = nameof(PackagePath);
 
+		/// <summary>
+		/// Whether the project can be packed as a .nupkg.
+		/// </summary>
+		public const string IsPackable = nameof(IsPackable);
+
 		public const string TargetFramework = nameof(TargetFramework);
 
 		public const string TargetFrameworkMoniker = nameof(TargetFrameworkMoniker);

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -20,7 +20,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<IncludeOutputs Condition="'$(IncludeOutputs)' == ''">true</IncludeOutputs>
 		<PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">false</PackageRequireLicenseAcceptance>
 		
+		<!-- NOTE: we will always have this property in projects referencing this targets file. Can be used to detect this. -->
 		<IsPackable Condition="'$(IsPackable)' == '' and '$(PackageId)' != ''">true</IsPackable>
+		<IsPackable Condition="'$(IsPackable)' == '' and '$(PackageId)' == ''">false</IsPackable>
+		
 		<!-- Directory where the .nupkg will be saved to if Pack is run -->
 		<PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(OutputPath)</PackageOutputPath>
 		<BuildDependsOn Condition="'$(PackOnBuild)' == 'true' and '$(IsPackable)' == 'true'">
@@ -29,14 +32,58 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</BuildDependsOn>
 	</PropertyGroup>
 
-	<!-- Redefine or provide a PackageVersion to override the default. -->
-	<Target Name="GetPackageVersion" Condition="'$(PackageVersion)' == ''">
+	<!--
+	============================================================
+					GetTargetPath
+
+    This target is redefined from the common targets to add the 
+	%(IsPackable) metadata, which is used by the GetPacakgeContents 
+	target to detect project references that don't have this 
+	nuget package installed (and would therefore not behave 
+	properly when packed from the referencing project).
+	============================================================
+	-->
+	<Target
+		Name="GetTargetPath"
+		DependsOnTargets="$(GetTargetPathDependsOn)"
+		Returns="@(TargetPathWithTargetPlatformMonikerAndIsPackable)">
+		<ItemGroup>
+			<TargetPathWithTargetPlatformMonikerAndIsPackable Include="$(TargetPath)">
+				<TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
+				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+				<IsPackable>$(IsPackable)</IsPackable>
+			</TargetPathWithTargetPlatformMonikerAndIsPackable>
+		</ItemGroup>
+	</Target>
+
+	<!--
+	============================================================
+					GetPackageVersion
+
+    This target sets the default $(PackageVersion) to $(Version) 
+	if empty, and returns it. 
+	
+	It can be redefined to change how the package version is 
+	determined.
+	============================================================
+	-->
+	<Target Name="GetPackageVersion" Condition="'$(PackageVersion)' == ''" Returns="$(PackageVersion)">
 		<PropertyGroup>
 			<PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
 		</PropertyGroup>
 	</Target>
 
-	<!-- Redefine or provide a PackageTargetPath to override the default. -->
+	<!--
+	============================================================
+					GetPackageTargetPath
+
+    This target sets the default $(PackageTargetPath) if it's 
+	empty and returns it.
+	
+	It can be redefined to change how the package target path is 
+	determined.	
+	============================================================
+	-->
 	<Target Name="GetPackageTargetPath" DependsOnTargets="GetPackageVersion" Returns="$(PackageTargetPath)">
 		<PropertyGroup>
 			<PackageTargetPath Condition="'$(PackageTargetPath)' == '' and '$(PackageId)' != ''">$([System.IO.Path]::Combine('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))</PackageTargetPath>
@@ -59,6 +106,25 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</_GetPackageContentsDependsOn>
 	</PropertyGroup>
 
+	<!--
+	============================================================
+					GetPackageContents
+
+    Returns the "virtual package" for the current project, containing 
+	all items that would end up in a .nupkg if the project were 
+	to be packed. 
+	
+	If the project has NuGet metadata to generate a .nupkg, a metadata 
+	item containing the manifest information will also be returned, as 
+	
+		Identity=$(PackageId)
+		   %(Kind)=Metadata
+		   ... all manifest values as metadata items ...
+	
+	All items returned from this target contain a %(PackageId) metadata 
+	with the project's $(PackageId), if any.
+	============================================================
+	-->
 	<Target Name="GetPackageContents" DependsOnTargets="$(_GetPackageContentsDependsOn)" Returns="@(_PackageContent)" />
 
 	<Target Name="_CollectPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)">
@@ -138,7 +204,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</_PackageContent>
 		</ItemGroup>
 
-		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
+    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
+				 Targets="GetTargetPath"
+				 BuildInParallel="$(BuildInParallel)"
+				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
+				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ReferencedTargetPath" />
+    </MSBuild>
+
+    <ItemGroup>
+      <UnknownPackableTargetPaths Include="@(_ReferencedTargetPath)" Condition="'%(_ReferencedTargetPath.IsPackable)' == ''" />
+    </ItemGroup>
+
+    <Error Text="Please install the required 'NuGet.Build.Packaging' package in the following projects: @(UnknownPackableTargetPaths-> '%(MSBuildSourceProjectFile)')" Code="NG1001" Condition="'@(UnknownPackableTargetPaths)' != ''" />
+
+    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
 				 Targets="GetPackageContents"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
@@ -184,6 +265,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</_PackDependsOn>
 	</PropertyGroup>
 
+	<!--
+	============================================================
+					Pack
+
+    Creates the output .nupkg if the project is packable.
+	============================================================
+	-->
 	<Target Name="Pack" DependsOnTargets="$(_PackDependsOn)" Returns="@(PackageTargetPath)" Condition="'$(IsPackable)' == 'true'" />
 
 	<Target Name="_Pack" DependsOnTargets="$(PackDependsOn)" Returns="@(PackageTargetPath)">

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -17,42 +17,26 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
-    <None Include="NuGet.Build.Packaging.Tests.targets">
-      <SubType>Designer</SubType>
-    </None>
-    <Content Include="Scenarios\given_a_complex_pack\a.csproj">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Scenarios\given_a_complex_pack\b.csproj">
-      <SubType>Designer</SubType>
-    </Content>
+    <None Include="NuGet.Build.Packaging.Tests.targets" />
+    <Content Include="Scenarios\given_a_complex_pack\a.csproj" />
+    <Content Include="Scenarios\given_a_complex_pack\b.csproj" />
     <Content Include="Scenarios\given_a_complex_pack\c.csproj" />
     <Content Include="Scenarios\given_a_complex_pack\d.csproj" />
     <Content Include="Scenarios\given_a_complex_pack\e.csproj" />
+    <Content Include="Scenarios\given_a_library_with_non_nugetized_reference\a.csproj" />
+    <Content Include="Scenarios\given_a_library_with_non_nugetized_reference\b.csproj" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.json" />
     <Content Include="Scenarios\given_library_project_with_nugets\project.lock.json" />
-    <None Include="Scenarios\Scenario.props">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="Scenarios\Scenario.props" />
     <None Include="Scenarios\Scenario.targets" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />
-    <Content Include="Scenarios\dynamic.csproj">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Scenarios\given_library_project_with_nugets\a.csproj">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Scenarios\given_an_empty_library_project\empty_library_project.csproj">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Scenarios\given_a_library_with_project_reference\a.csproj">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Scenarios\given_a_library_with_project_reference\b.csproj">
-      <SubType>Designer</SubType>
-    </Content>
+    <Content Include="Scenarios\dynamic.csproj" />
+    <Content Include="Scenarios\given_library_project_with_nugets\a.csproj" />
+    <Content Include="Scenarios\given_an_empty_library_project\empty_library_project.csproj" />
+    <Content Include="Scenarios\given_a_library_with_project_reference\a.csproj" />
+    <Content Include="Scenarios\given_a_library_with_project_reference\b.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CreatePackageTests.cs" />
@@ -62,6 +46,7 @@
       <DependentUpon>Builder.cs</DependentUpon>
     </Compile>
     <Compile Include="given_a_complex_pack.cs" />
+    <Compile Include="given_a_library_with_non_nugetized_reference.cs" />
     <Compile Include="given_library_project_with_nugets.cs" />
     <Compile Include="given_an_empty_library_project.cs" />
     <Compile Include="given_a_library_with_project_reference.cs" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_non_nugetized_reference/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_non_nugetized_reference/a.csproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="b.csproj">
+        <Project>$(GuidB)</Project>
+        <Name>b</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_non_nugetized_reference/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_non_nugetized_reference/b.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+  <PropertyGroup>
+    <ProjectGuid>$(GuidB)</ProjectGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using NuGet.Build.Packaging.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.Build.Packaging
+{
+	public class given_a_library_with_non_nugetized_reference
+	{
+		ITestOutputHelper output;
+
+		public given_a_library_with_non_nugetized_reference(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public void when_getting_nugetized_target_path_then_it_contains_ispackable_metadata()
+		{
+			var result = Builder.BuildScenario(
+				nameof(given_a_library_with_non_nugetized_reference), 
+				target: "GetTargetPath",
+				output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.True(result.Items[0].MetadataNames.OfType<string>().Contains(MetadataName.IsPackable));
+		}
+
+		[Fact]
+		public void when_getting_non_nugetized_target_path_then_it_does_not_contains_ispackable_metadata()
+		{
+			var result = Builder.BuildScenario(
+				nameof(given_a_library_with_non_nugetized_reference),
+				projectName: "b",
+				target: "GetTargetPath",
+				output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.False(result.Items[0].MetadataNames.OfType<string>().Contains(MetadataName.IsPackable));
+		}
+
+		[Fact]
+		public void when_getting_package_contents_then_fails_for_non_nugetized_reference()
+		{
+			var result = Builder.BuildScenario(
+				nameof(given_a_library_with_non_nugetized_reference),
+				target: "GetPackageContents",
+				output: output);
+
+			Assert.Equal(TargetResultCode.Failure, result.ResultCode);
+		}
+	}
+}


### PR DESCRIPTION
Instead of failing to invoke a non-existing target, determine
up-front if the referenced project has the NuGetizer nuget
package installed by inspecting the metadata of the target
path.
