### PR TITLE
Add support for framework references

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -94,6 +94,7 @@ namespace NuGet.Build.Packaging.Tasks
 
 			AddDependencies(manifest);
 			AddFiles(manifest);
+			AddFrameworkAssemblies(manifest);
 
 			return manifest;
 		}
@@ -135,6 +136,19 @@ namespace NuGet.Build.Packaging.Tasks
 					Source = item.GetMetadata("FullPath"),
 					Target = item.GetMetadata(MetadataName.PackagePath),
 				}));
+		}
+
+		void AddFrameworkAssemblies(Manifest manifest)
+		{
+			var frameworkReferences = from item in Contents
+									  where item.GetMetadata(MetadataName.Kind) == PackageItemKind.FrameworkReference
+									  select new FrameworkAssemblyReference
+									  (
+										  item.ItemSpec,
+										  new [] { NuGetFramework.Parse(item.GetTargetFrameworkMoniker().FullName) }
+									  );
+
+			manifest.Metadata.FrameworkReferences = frameworkReferences;
 		}
 
 		void BuildPackage(Stream output)

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -18,6 +18,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<PropertyGroup>
 		<IncludeSymbols Condition="'$(IncludeSymbols)' == '' and '$(Configuration)' == 'Debug'">true</IncludeSymbols>
 		<IncludeOutputs Condition="'$(IncludeOutputs)' == ''">true</IncludeOutputs>
+		<IncludeFrameworkReferences Condition="'$(IncludeFrameworkReferences)' == ''">true</IncludeFrameworkReferences>
+		
 		<PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">false</PackageRequireLicenseAcceptance>
 
 		<!-- NOTE: we will always have this property in projects referencing this targets file. Can be used to detect this. -->
@@ -155,7 +157,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 			GetAllPackageContents;
 			_GetPackageContents;
 		</_GetPackageContentsDependsOn>
+		<!-- Only depend on ResolveReferences if we need to include framework references -->
+		<_GetAllPackageContentsDependsOn Condition="'$(IncludeFrameworkReferences)' == 'true'">
+			ResolveReferences
+		</_GetAllPackageContentsDependsOn>
 		<_GetAllPackageContentsDependsOn>
+			$(_GetAllPackageContentsDependsOn);
 			GetPackageTargetPath;
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
@@ -253,6 +260,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 			<PackageFile Include="@(PackageReference)">
 				<Kind>Dependency</Kind>
+			</PackageFile>
+
+			<!-- We can't use %(FrameworkFile)==true because it's not defined for raw file references and 
+			     it also includes mscorlib which we don't need -->
+			<PackageFile Include="@(ReferencePath->'%(OriginalItemSpec)')" 
+						 Condition="'$(IncludeFrameworkReferences)' == 'true' and '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
+				<Kind>FrameworkReference</Kind>
 			</PackageFile>
 		</ItemGroup>
 

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -172,5 +172,37 @@ namespace NuGet.Build.Packaging
 			Assert.NotNull(manifest);
 			Assert.Contains(manifest.Files, file => file.Target == "readme.txt");
 		}
+
+		[Fact]
+		public void when_creating_package_with_framework_reference_then_contains_references()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
+				}),
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(manifest.Metadata.FrameworkReferences,
+				new[]
+				{
+					new FrameworkAssemblyReference("System.Xml", new [] { NuGetFramework.Parse(TargetFrameworks.NET45) }),
+					new FrameworkAssemblyReference("System.Xml", new [] { NuGetFramework.Parse(TargetFrameworks.PCL78) }),
+				}, 
+				FrameworkAssemblyReferenceComparer.Default);
+
+			Assert.NotNull(manifest);
+		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -51,8 +51,10 @@
     <Compile Include="given_an_empty_library_project.cs" />
     <Compile Include="given_a_library_with_project_reference.cs" />
     <Compile Include="UtilitiesTests.cs" />
+    <Compile Include="Utilities\FrameworkAssemblyReferenceComparer.cs" />
     <Compile Include="Utilities\MockBuildEngine.cs" />
     <Compile Include="Utilities\ModuleInitializer.cs" />
+    <Compile Include="Utilities\TargetFrameworks.cs" />
     <Compile Include="Utilities\TaskItemExtensions.cs" />
     <Compile Include="Utilities\TestOutputLogger.cs" />
   </ItemGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/FrameworkAssemblyReferenceComparer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/FrameworkAssemblyReferenceComparer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging;
+
+namespace NuGet.Build.Packaging
+{
+	public class FrameworkAssemblyReferenceComparer : IEqualityComparer<FrameworkAssemblyReference>
+    {
+		public static FrameworkAssemblyReferenceComparer Default { get; private set; }
+
+		static FrameworkAssemblyReferenceComparer()
+		{
+			Default = new FrameworkAssemblyReferenceComparer(StringComparer.OrdinalIgnoreCase);
+		}
+
+        StringComparer comparer;
+
+        private FrameworkAssemblyReferenceComparer(StringComparer comparer)
+        {
+            this.comparer = comparer;
+        }
+
+        public bool Equals(FrameworkAssemblyReference x, FrameworkAssemblyReference y)
+        {
+            if (x == null && x == null)
+                return true;
+
+            if (x == null || y == null)
+                return false;
+
+            return comparer.Equals(x.AssemblyName, y.AssemblyName)
+                && comparer.Equals(GetSupportedFrameworks(x), GetSupportedFrameworks(y));
+        }
+
+        public int GetHashCode(FrameworkAssemblyReference obj)
+        {
+            if (obj == null)
+                throw new ArgumentNullException("obj");
+
+            return comparer.GetHashCode(obj.AssemblyName ?? "")
+                + comparer.GetHashCode(GetSupportedFrameworks(obj));
+        }
+
+        static string GetSupportedFrameworks(FrameworkAssemblyReference obj)
+        {
+            if (obj.SupportedFrameworks == null)
+                return "";
+
+            return string.Join(",", obj.SupportedFrameworks.Select(framework => framework.ToString()));
+        }
+    }
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/TargetFrameworks.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/TargetFrameworks.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Build.Packaging
+{
+	public static class TargetFrameworks
+	{
+		public const string NET45 = ".NETFramework,Version=v4.5";
+		public const string NET46 = ".NETFramework,Version=v4.6";
+		public const string PCL78 = ".NETPortable,Version=v4.0,Profile=Profile78";
+		public const string XI10 = "Xamarin.iOS,Version=v1.0";
+		public const string XA50 = "MonoAndroid,Version=v5.0";
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
@@ -34,15 +34,24 @@ namespace NuGet.Build.Packaging
 			Assert.True(result.Items.Any(i => i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == "Symbols"), "Did not include main symbols");
 		}
 
-		[Verbosity(Microsoft.Build.Framework.LoggerVerbosity.Diagnostic)]
 		[Fact]
 		public void when_getting_package_contents_then_annotates_items_with_package_id()
 		{
-			var result = Builder.BuildScenario(nameof(given_an_empty_library_project), new { PackageId = "Foo" });
+			var result = Builder.BuildScenario(nameof(given_an_empty_library_project), new { PackageId = "Foo" }, output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
 			Assert.True(result.Items.All(i => i.GetMetadata("PackageId") == "Foo"), "Did not annotate contents with package id.");
+		}
+
+		[Fact]
+		public void when_getting_package_contents_then_contains_framework_reference()
+		{
+			var result = Builder.BuildScenario(nameof(given_an_empty_library_project), new { PackageId = "Foo" }, output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.True(result.Items.Any(i => i.ItemSpec == "System.Core" && i.GetMetadata("Kind") == "FrameworkReference"), "Did not add System.Core framework reference.");
 		}
 	}
 }

--- a/src/NuGet.Build.Packaging.IntellisenseFixup.targets
+++ b/src/NuGet.Build.Packaging.IntellisenseFixup.targets
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Fix a broken IDE build caused by Fody. See https://github.com/Fody/Fody/pull/264 -->
-  <Target Name="FodyTarget" />
-  <Target Name="FodyVerifyTarget" />
-</Project>

--- a/src/NuGet.Build.Packaging.Shared.targets
+++ b/src/NuGet.Build.Packaging.Shared.targets
@@ -31,8 +31,6 @@ namespace $(ThisAssemblyNamespace)
 	</Target>
 
   <Import Project="$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets" Condition="Exists('$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets')" />
-  <!-- Fix a broken IDE build caused by Fody. See https://github.com/Fody/Fody/pull/264 -->
-  <Import Project="NuGet.Build.Packaging.IntellisenseFixup.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true'" />
 
   <ItemGroup Condition=" '$(NoGlobalAssemblyInfo)' != 'true' And '$(Language)' == 'C#' ">
     <Compile Include="$(MSBuildThisFileDirectory)GlobalAssemblyInfo.cs" Condition="'$(BuildingProject)' == 'true'" />


### PR DESCRIPTION
Can be opted out by setting $(IncludeFrameworkReferences)='false'.

Will by default add all @(ReferencePath) that have ResolvedFrom={TargetFrameworkDirectory}
