### PR TITLE
Add support for contentFiles and their metadata values

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/AssignPackagePath.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/AssignPackagePath.cs
@@ -93,7 +93,7 @@ namespace NuGet.Build.Packaging.Tasks
 			if (packageFolder == PackagingConstants.Folders.ContentFiles)
 			{
 				/// See https://docs.nuget.org/create/nuspec-reference#contentfiles-with-visual-studio-2015-update-1-and-later
-				var codeLanguage = file.GetMetadata(nameof(PropertyNames.CodeLanguage));
+				var codeLanguage = file.GetMetadata(MetadataName.ContentFile.CodeLanguage);
 				if (string.IsNullOrEmpty(codeLanguage))
 					codeLanguage = PackagingConstants.AnyFramework;
 

--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -130,13 +130,25 @@ namespace NuGet.Build.Packaging.Tasks
 
 		void AddFiles(Manifest manifest)
 		{
-			manifest.Files.AddRange(Contents
-				.Where(item => !string.IsNullOrEmpty(item.GetMetadata(MetadataName.PackagePath)))
-				.Select(item => new ManifestFile
+			var contents = Contents.Where(item => 
+				!string.IsNullOrEmpty(item.GetMetadata(MetadataName.PackagePath)));
+
+			var files = contents.Where(item => item.GetMetadata(MetadataName.PackageFolder) != PackagingConstants.Folders.ContentFiles);
+			var contentFiles = contents.Where(item => item.GetMetadata(MetadataName.PackageFolder) == PackagingConstants.Folders.ContentFiles);
+
+			manifest.Files.AddRange(files.Select(item => new ManifestFile
 				{
 					Source = item.GetMetadata("FullPath"),
 					Target = item.GetMetadata(MetadataName.PackagePath),
 				}));
+
+			manifest.Metadata.ContentFiles = contentFiles.Select(item => new ManifestContentFiles
+			{
+				Include = item.GetMetadata("FullPath"), 
+				BuildAction = item.GetNullableMetadata(MetadataName.ContentFile.BuildAction),
+				CopyToOutput = item.GetNullableMetadata(MetadataName.ContentFile.CopyToOutput),
+				Flatten = item.GetNullableMetadata(MetadataName.ContentFile.Flatten),
+			}).ToArray();
 		}
 
 		void AddFrameworkAssemblies(Manifest manifest)

--- a/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
@@ -25,6 +25,15 @@ namespace NuGet.Build.Packaging
 			return bool.TryParse(metadataValue, out result) && result;
 		}
 
+		public static string GetNullableMetadata(this ITaskItem taskItem, string metadataName)
+		{
+			var value = taskItem.GetMetadata(metadataName);
+			if (string.IsNullOrEmpty(value))
+				return null;
+
+			return value;
+		}
+
 		public static Manifest GetManifest(this IPackageCoreReader packageReader)
 		{
 			using (var stream = packageReader.GetNuspec())

--- a/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
@@ -38,5 +38,16 @@
 		public const string TargetFramework = nameof(TargetFramework);
 
 		public const string TargetFrameworkMoniker = nameof(TargetFrameworkMoniker);
+
+		/// <summary>
+		/// Available optional metadata values of contentFiles.
+		/// </summary>
+		public static class ContentFile
+		{
+			public const string CodeLanguage = nameof(CodeLanguage);
+			public const string BuildAction = nameof(BuildAction);
+			public const string CopyToOutput = nameof(CopyToOutput);
+			public const string Flatten = nameof(Flatten);
+		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
@@ -52,6 +52,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</PackageItemKind>
 		<PackageItemKind Include="ContentFiles">
 			<PackageFolder>contentFiles</PackageFolder>
+			<!-- Additional optional metadata: -->
+			<!-- CodeLanguage: any (default), cs, fs, vb -->
+			<!-- BuildAction: Compile (default), None, EmbeddedResource -->
+			<!-- CopyToOutput: false (default) / true -->
+			<!-- Flatten: false (default) / true -->
 		</PackageItemKind>
 		<PackageItemKind Include="Native">
 			<PackageFolder>native</PackageFolder>

--- a/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/AssignPackagePathTests.cs
@@ -335,6 +335,38 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
+		public void when_assigning_content_file_with_additional_metadata_then_preserves_metadata()
+		{
+			var task = new AssignPackagePath
+			{
+				BuildEngine = engine,
+				Kinds = kinds,
+				Files = new ITaskItem[]
+				{
+					new TaskItem("Sample.cs", new Metadata
+					{
+						{ "PackageId", "A" },
+						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+						{ "Kind", "Content" },
+						{ MetadataName.ContentFile.CodeLanguage, "cs" },
+						{ MetadataName.ContentFile.BuildAction, "EmbeddedResource" },
+						{ MetadataName.ContentFile.CopyToOutput, "true" },
+						{ MetadataName.ContentFile.Flatten, "true" },
+					})
+				}
+			};
+
+			Assert.True(task.Execute());
+
+			var item = task.AssignedFiles[0];
+
+			Assert.Equal("cs", item.GetMetadata(MetadataName.ContentFile.CodeLanguage));
+			Assert.Equal("EmbeddedResource", item.GetMetadata(MetadataName.ContentFile.BuildAction));
+			Assert.Equal("true", item.GetMetadata(MetadataName.ContentFile.CopyToOutput));
+			Assert.Equal("true", item.GetMetadata(MetadataName.ContentFile.Flatten));
+		}
+
+		[Fact]
 		public void when_file_has_none_kind_then_assigned_file_has_empty_package_folder()
 		{
 			var task = new AssignPackagePath

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -224,6 +224,165 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
+		public void when_creating_package_with_content_file_then_adds_as_content_file()
+		{
+			var none = Path.GetTempFileName();
+			var content = Path.GetTempFileName();
+			task.Contents = new[]
+			{
+				new TaskItem(none, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackagePath, "readme.txt" }
+				}),
+				new TaskItem(content, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
+					{ MetadataName.PackagePath, "contentFiles/any/any/readme.txt" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(new[]
+				{
+					new ManifestFile { Source = none, Target = "readme.txt" }
+				},
+				manifest.Files,
+				ManifestFileComparer.Default);
+
+			Assert.Equal(new []
+				{
+					new ManifestContentFiles { Include = content }
+				},
+				manifest.Metadata.ContentFiles,
+				ManifestContentFilesComparer.Default);
+		}
+
+		[Fact]
+		public void when_creating_package_with_content_file_build_action_then_adds_as_content_file()
+		{
+			var none = Path.GetTempFileName();
+			var content = Path.GetTempFileName();
+			task.Contents = new[]
+			{
+				new TaskItem(none, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackagePath, "readme.txt" }
+				}),
+				new TaskItem(content, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
+					{ MetadataName.ContentFile.BuildAction, "EmbeddedResource" },
+					{ MetadataName.PackagePath, "contentFiles/any/any/readme.txt" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(new[]
+				{
+					new ManifestFile { Source = none, Target = "readme.txt" }
+				},
+				manifest.Files,
+				ManifestFileComparer.Default);
+
+			Assert.Equal(new[]
+				{
+					new ManifestContentFiles { Include = content, BuildAction = "EmbeddedResource" }
+				},
+				manifest.Metadata.ContentFiles,
+				ManifestContentFilesComparer.Default);
+		}
+
+		[Fact]
+		public void when_creating_package_with_content_file_copy_to_output_then_adds_as_content_file()
+		{
+			var none = Path.GetTempFileName();
+			var content = Path.GetTempFileName();
+			task.Contents = new[]
+			{
+				new TaskItem(none, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackagePath, "readme.txt" }
+				}),
+				new TaskItem(content, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
+					{ MetadataName.ContentFile.CopyToOutput, "true" },
+					{ MetadataName.PackagePath, "contentFiles/any/any/readme.txt" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(new[]
+				{
+					new ManifestFile { Source = none, Target = "readme.txt" }
+				},
+				manifest.Files,
+				ManifestFileComparer.Default);
+
+			Assert.Equal(new[]
+				{
+					new ManifestContentFiles { Include = content, CopyToOutput = "true" }
+				},
+				manifest.Metadata.ContentFiles,
+				ManifestContentFilesComparer.Default);
+		}
+
+		[Fact]
+		public void when_creating_package_with_content_file_flatten_then_adds_as_content_file()
+		{
+			var none = Path.GetTempFileName();
+			var content = Path.GetTempFileName();
+			task.Contents = new[]
+			{
+				new TaskItem(none, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackagePath, "readme.txt" }
+				}),
+				new TaskItem(content, new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
+					{ MetadataName.ContentFile.Flatten, "true" },
+					{ MetadataName.PackagePath, "contentFiles/any/any/readme.txt" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(new[]
+				{
+					new ManifestFile { Source = none, Target = "readme.txt" }
+				},
+				manifest.Files,
+				ManifestFileComparer.Default);
+
+			Assert.Equal(new[]
+				{
+					new ManifestContentFiles { Include = content, Flatten = "true" }
+				},
+				manifest.Metadata.ContentFiles,
+				ManifestContentFilesComparer.Default);
+		}
+
+		[Fact]
 		public void when_creating_package_with_framework_reference_then_contains_references()
 		{
 			task.Contents = new[]

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -54,8 +54,10 @@
     <Compile Include="given_a_library_with_project_reference.cs" />
     <Compile Include="UtilitiesTests.cs" />
     <Compile Include="Utilities\FrameworkAssemblyReferenceComparer.cs" />
+    <Compile Include="Utilities\ManifestContentFilesComparer.cs" />
     <Compile Include="Utilities\MockBuildEngine.cs" />
     <Compile Include="Utilities\ModuleInitializer.cs" />
+    <Compile Include="Utilities\ManifestFileComparer.cs" />
     <Compile Include="Utilities\PackageDependencyComparer.cs" />
     <Compile Include="Utilities\PackageDependencyGroupComparer.cs" />
     <Compile Include="Utilities\TargetFrameworks.cs" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/ManifestContentFilesComparer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/ManifestContentFilesComparer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Build.Packaging
+{
+	public class ManifestContentFilesComparer : IEqualityComparer<ManifestContentFiles>
+	{
+		public static ManifestContentFilesComparer Default { get; } = new ManifestContentFilesComparer();
+
+        public bool Equals(ManifestContentFiles x, ManifestContentFiles y)
+        {
+            if (x == null && x == null)
+                return true;
+            if (x == null || y == null)
+                return false;
+
+			return StringComparer.OrdinalIgnoreCase.Equals(x.Include, y.Include)
+				&& StringComparer.OrdinalIgnoreCase.Equals(x.BuildAction, y.BuildAction)
+				&& StringComparer.OrdinalIgnoreCase.Equals(x.CopyToOutput, x.CopyToOutput)
+				&& StringComparer.OrdinalIgnoreCase.Equals(x.Flatten, x.Flatten);
+        }
+
+        public int GetHashCode(ManifestContentFiles obj)
+        {
+            if (obj == null)
+                throw new ArgumentNullException("obj");
+
+			return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Include ?? "")
+				+ StringComparer.OrdinalIgnoreCase.GetHashCode(obj.BuildAction ?? "")
+				+ StringComparer.OrdinalIgnoreCase.GetHashCode(obj.CopyToOutput ?? "")
+				+ StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Flatten ?? "");
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/Utilities/ManifestFileComparer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Utilities/ManifestFileComparer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Build.Packaging
+{
+	public class ManifestFileComparer : IEqualityComparer<ManifestFile>
+    {
+		public static ManifestFileComparer Default { get; } = new ManifestFileComparer();
+
+        public bool Equals(ManifestFile x, ManifestFile y)
+        {
+            if (x == null && x == null)
+                return true;
+            if (x == null || y == null)
+                return false;
+
+			// We don't compare the Source since it's different for packaged manifests 
+			return StringComparer.OrdinalIgnoreCase.Equals(x.Target, y.Target)
+				&& StringComparer.OrdinalIgnoreCase.Equals(x.Exclude, x.Exclude);
+        }
+
+        public int GetHashCode(ManifestFile obj)
+        {
+            if (obj == null)
+                throw new ArgumentNullException("obj");
+
+			return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Target ?? "")
+				+ StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Exclude ?? "");
+		}
+	}
+}


### PR DESCRIPTION
Allows BuildAction, CopyToOutput and Flatten metadata
attributes in PackageFiles of kind Content or ContentFiles.
