### PR TITLE
Add support for setting NuGet properties via Properties Window

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
@@ -102,9 +102,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<!-- Platform targets could turn @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to FrameworkReference, for example -->
 		<PackageItemKind Include="FrameworkReference" />
 
-		<!-- Platform targets cound turn other @(ReferencePath) that are resolved otherwise (i.e. {RawFile}) into AssemblyReference, for example -->
-		<PackageItemKind Include="AssemblyReference" />
-
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.csproj
@@ -77,6 +77,8 @@
       <Link>PropertyPageBase\UserEditCompleteHandler.cs</Link>
     </Compile>
     <Compile Include="Commands\AddPlatformImplementationCommand.cs" />
+    <Compile Include="ProjectExtender\NuGetExtender.cs" />
+    <Compile Include="ProjectExtender\NuGetExtenderProvider.cs" />
     <Compile Include="ProjectSystem.Dev14\NuProjCapabilities.cs" />
     <Compile Include="ProjectSystem.Dev14\NuProjConfiguredProject.cs" />
     <Compile Include="ProjectSystem.Dev14\NuProjProjectCapabilitiesProvider.cs" />
@@ -179,10 +181,10 @@
     <ProjectReference Include="..\..\Build\NuGet.Build.Packaging.Authoring.Tasks\NuGet.Build.Packaging.Authoring.Tasks.csproj">
       <Project>{f145ce58-06aa-4499-89d5-e5144b38d8f3}</Project>
       <Name>NuGet.Build.Packaging.Authoring.Tasks</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <AdditionalProperties>PackOnBuild=true</AdditionalProperties>
       <IncludeOutputGroupsInVSIXLocalOnly>PackageOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <IncludeOutputGroupsInVSIX>PackageOutputGroup</IncludeOutputGroupsInVSIX>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/ProjectExtender/NuGetExtender.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/ProjectExtender/NuGetExtender.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGet.Packaging.VisualStudio
+{
+	[ComVisible(true)]
+	[ClassInterface(ClassInterfaceType.AutoDispatch)]
+	public class NuGetExtender 
+	{
+		const string CategoryName = "NuGet";
+
+		readonly IVsBuildPropertyStorage propertyStorage;
+
+		internal NuGetExtender(IVsHierarchy hierarchy)
+		{
+			propertyStorage = (IVsBuildPropertyStorage)hierarchy;
+		}
+
+		[DefaultValue("")]
+		[Description("Package identifier.")]
+		[DisplayName("Id")]
+		[Category(CategoryName)]
+		public string PackageId
+		{
+			get { return GetGlobalProperty(nameof(PackageId), ""); }
+			set { SetGlobalProperty(nameof(PackageId), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Description("Package version.")]
+		[DisplayName("Version")]
+		[Category(CategoryName)]
+		public string PackageVersion
+		{
+			get { return GetGlobalProperty(nameof(PackageVersion), ""); }
+			set { SetGlobalProperty(nameof(PackageVersion), value, ""); }
+		}
+
+		[DefaultValue(false)]
+		[Description("Specifies if the project generates a development dependency package.")]
+		[DisplayName("Is Development Dependency")]
+		[Category(CategoryName)]
+		public bool IsDevelopmentDependency
+		{
+			get { return GetGlobalProperty(nameof(IsDevelopmentDependency), false); }
+			set { SetGlobalProperty(nameof(IsDevelopmentDependency), value, false); }
+		}
+
+		[DefaultValue("")]
+		[Category(CategoryName)]
+		public string Authors
+		{
+			get { return GetGlobalProperty(nameof(Authors), ""); }
+			set { SetGlobalProperty(nameof(Authors), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Category(CategoryName)]
+		public string Title
+		{
+			get { return GetGlobalProperty(nameof(Title), ""); }
+			set { SetGlobalProperty(nameof(Title), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Category(CategoryName)]
+		public string Description
+		{
+			get { return GetGlobalProperty(nameof(Description), ""); }
+			set { SetGlobalProperty(nameof(Description), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Category(CategoryName)]
+		public string Summary
+		{
+			get { return GetGlobalProperty(nameof(Summary), ""); }
+			set { SetGlobalProperty(nameof(Summary), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Language")]
+		[Category(CategoryName)]
+		public string NeutralLanguage
+		{
+			get { return GetGlobalProperty(nameof(NeutralLanguage), ""); }
+			set { SetGlobalProperty(nameof(NeutralLanguage), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Category(CategoryName)]
+		public string Copyright
+		{
+			get { return GetGlobalProperty(nameof(Copyright), ""); }
+			set { SetGlobalProperty(nameof(Copyright), value, ""); }
+		}
+
+		[DefaultValue(false)]
+		[DisplayName("Require License Acceptance")]
+		[Category(CategoryName)]
+		public bool PackageRequireLicenseAcceptance
+		{
+			get { return GetGlobalProperty(nameof(PackageRequireLicenseAcceptance), false); }
+			set { SetGlobalProperty(nameof(PackageRequireLicenseAcceptance), value, false); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("License Url")]
+		[Category(CategoryName)]
+		public string PackageLicenseUrl
+		{
+			get { return GetGlobalProperty(nameof(PackageLicenseUrl), ""); }
+			set { SetGlobalProperty(nameof(PackageLicenseUrl), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Project Url")]
+		[Category(CategoryName)]
+		public string PackageProjectUrl
+		{
+			get { return GetGlobalProperty(nameof(PackageProjectUrl), ""); }
+			set { SetGlobalProperty(nameof(PackageProjectUrl), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Icon Url")]
+		[Category(CategoryName)]
+		public string PackageIconUrl
+		{
+			get { return GetGlobalProperty(nameof(PackageIconUrl), ""); }
+			set { SetGlobalProperty(nameof(PackageIconUrl), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Description("A space-delimited list of tags and keywords that describe the package.")]
+		[DisplayName("Tags")]
+		[Category(CategoryName)]
+		public string PackageTags
+		{
+			get { return GetGlobalProperty(nameof(PackageTags), ""); }
+			set { SetGlobalProperty(nameof(PackageTags), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Release Notes")]
+		[Category(CategoryName)]
+		public string PackageReleaseNotes
+		{
+			get { return GetGlobalProperty(nameof(PackageReleaseNotes), ""); }
+			set { SetGlobalProperty(nameof(PackageReleaseNotes), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Repository Url")]
+		[Category(CategoryName)]
+		public string RepositoryUrl
+		{
+			get { return GetGlobalProperty(nameof(RepositoryUrl), ""); }
+			set { SetGlobalProperty(nameof(RepositoryUrl), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[DisplayName("Repository Type")]
+		[Category(CategoryName)]
+		public string RepositoryType
+		{
+			get { return GetGlobalProperty(nameof(RepositoryType), ""); }
+			set { SetGlobalProperty(nameof(RepositoryType), value, ""); }
+		}
+
+		[DefaultValue("")]
+		[Description("A comma-delimited list of package types that indicate how a package is intended to be used, such as 'Dependency' and 'DotnetCliTool'.")]
+		[DisplayName("Package Types")]
+		[Category(CategoryName)]
+		public string PackageTypes
+		{
+			get { return GetGlobalProperty(nameof(PackageTypes), ""); }
+			set { SetGlobalProperty(nameof(PackageTypes), value, ""); }
+		}
+
+		bool GetGlobalProperty(string propertyName, bool defaultValue)
+		{
+			var value = GetGlobalProperty(propertyName, defaultValue.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+			bool result;
+			if (!bool.TryParse(value, out result))
+			{
+				return defaultValue;
+			}
+
+			return result;
+		}
+
+		void SetGlobalProperty(string propertyName, bool value, bool defaultValue)
+		{
+			SetGlobalProperty(propertyName, 
+				value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant(),
+				defaultValue.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+		}
+
+		string GetGlobalProperty(string propertyName, string defaultValue)
+		{
+			string value;
+
+			// Get the evaluated property value with null condition.
+			// Why null and not String.Empty?
+			// There is performance and (functionality implications) for String.Empty condition. 
+			// String.Empty will force us to reevaluate the project with Config = "" and Platform = "", read the value, 
+			// and reevaluate back. This ensures that only not conditional property value is read.But the price is we reevaluating twice. 
+			// "null" means we will just read the value using the current evaluation setitings. 
+			// If property is defined in "gobal" secitopn this is the same.
+			// If property is "overriden" in "confug" section it will in fact get this value, 
+			// but apart that the contract is already broken, that would be the value 
+			// that will be assigned during build for task to access anyway so it will be the "truth".
+			int hr = propertyStorage.GetPropertyValue(propertyName, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out value);
+			if (!ErrorHandler.Succeeded(hr) || string.IsNullOrEmpty(value))
+			{
+				return defaultValue;
+			}
+
+			return value;
+		}
+
+		void SetGlobalProperty(string propertyName, string value, string defaultValue)
+		{
+			if (string.IsNullOrEmpty(value) || value == defaultValue)
+			{
+				propertyStorage.RemoveProperty(
+					propertyName,
+					string.Empty,
+					(uint)_PersistStorageType.PST_PROJECT_FILE);
+			}
+			else
+			{
+				// Set the property with String.Empty condition to ensure it's global (not configuration scoped).
+				propertyStorage.SetPropertyValue(
+					propertyName,
+					string.Empty,
+					(uint)_PersistStorageType.PST_PROJECT_FILE,
+					value);
+			}
+		}
+	}
+}

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/ProjectExtender/NuGetExtenderProvider.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/ProjectExtender/NuGetExtenderProvider.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSLangProj;
+
+namespace NuGet.Packaging.VisualStudio
+{
+	public class NuGetExtenderProvider : EnvDTE.IExtenderProvider
+	{
+		internal const string ExtenderName = "NuGetExtenderProvider";
+		static bool inCanExtend = false;
+
+		public static IEnumerable<string> CategoryIds => new HashSet<string>(new[]
+		{
+			PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject,
+			PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject,
+		}, StringComparer.OrdinalIgnoreCase);
+
+		public bool CanExtend(string ExtenderCATID, string ExtenderName, object ExtendeeObject)
+		{
+			// check if provider can create extender for the given
+			// ExtenderCATID, ExtenderName, and Extendee instance
+			var extendeeCATIDProp = TypeDescriptor.GetProperties(ExtendeeObject)["ExtenderCATID"];
+
+			//Recursion Guard: We need to check the "Build Action" property in HasContentBuildAction.
+			//However, accessing this property will cause the Extender list to be built again, meaning 
+			//that VS will call into our CanExtend method again. In this case, just return false.
+			if (inCanExtend) return false;
+
+			inCanExtend = true;
+			var returnValue = ExtenderName.Equals(ExtenderName)
+				&& IsSupportedCATID(ExtenderCATID)
+				&& extendeeCATIDProp != null
+				&& IsSupportedCATID(extendeeCATIDProp.GetValue(ExtendeeObject).ToString());
+
+			inCanExtend = false;
+
+			return returnValue;
+		}
+
+		private bool IsSupportedCATID(string ExtenderCATID)
+		{
+			return CategoryIds.Contains(ExtenderCATID);
+		}
+
+		public object GetExtender(string ExtenderCATID,
+								  string ExtenderName,
+								  object ExtendeeObject,
+								  IExtenderSite ExtenderSite,
+								  int Cookie)
+		{
+			if (CanExtend(ExtenderCATID, ExtenderName, ExtendeeObject))
+			{
+				var browseObject = ExtendeeObject as IVsBrowseObject;
+				if (browseObject != null)
+				{
+					IVsHierarchy hierarchy;
+					uint itemId;
+					int hr = browseObject.GetProjectItem(out hierarchy, out itemId);
+					if (ErrorHandler.Succeeded(hr) && hierarchy != null)
+					{
+						return new NuGetExtender(hierarchy);
+					}
+				}
+			}
+
+			return null;
+		}
+
+		public object GetExtenderNames(string ExtenderCATID, object ExtendeeObject)
+		{
+			return new string[] { ExtenderName };
+		}
+	}
+}

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/VsPackage.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/VsPackage.cs
@@ -5,8 +5,14 @@
 	using Microsoft.VisualStudio.Shell;
 	using System.ComponentModel.Design;
 	using Microsoft.VisualStudio.ComponentModelHost;
+	using EnvDTE;
+	using Microsoft.VisualStudio.Shell.Interop;
 
 	[Guid(Guids.PackageGuid)]
+	[ProvideAutoLoad(UIContextGuids.SolutionExists)]
+	// TODO: make sure we only auto-load when there are C# and VB projects. (what about F#?)
+	//[ProvideAutoLoad("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}")]
+	//[ProvideAutoLoad("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}")]
 	[PackageRegistration(UseManagedResourcesOnly = true)]
 	[ProvideObject(typeof(NuSpecPropertyPage), RegisterUsing = RegistrationMethod.CodeBase)]
 	[ProvideProjectFactory(
@@ -27,6 +33,16 @@
 
 			RegisterProjectFactory(new NuProjFlavoredProjectFactory(this));
 			RegisterCommands();
+
+			var extenders = this.GetService<ObjectExtenders>();
+			if (extenders != null)
+			{
+				var provider = new NuGetExtenderProvider();
+				foreach (var category in NuGetExtenderProvider.CategoryIds)
+				{
+					extenders.RegisterExtenderProvider(category, NuGetExtenderProvider.ExtenderName, provider);
+				}
+			}
 		}
 
 		void RegisterCommands()


### PR DESCRIPTION
Until we have auto-flavoring in place, it's convenient to start
testing the NuGetizer targets by just setting NuGet properties
at the project level from the Properties Window. Eventually
setting these properties might cause the auto-flavoring too.

Without auto-flavoring, this is the only way we can provide NuGet
property editing for project flavors we don't control (i.e. class
libraries or portable libraries).
