### PR TITLE
Include tasks projects on build from VS and command line

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Authoring.Tasks/NuGet.Build.Packaging.Authoring.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Authoring.Tasks/NuGet.Build.Packaging.Authoring.Tasks.targets
@@ -3,6 +3,8 @@
 	<PropertyGroup>
 		<PackageId>NuGet.Build.Packaging.Authoring</PackageId>
 		<Description>NuGet Project System Targets</Description>
+		<!-- Turn on PackOnBuild when developing the VS integration, for F5 convenience. -->
+		<PackOnBuild Condition="'$(SolutionName)' == 'NuGet.Packaging.VisualStudio' and '$(BuildingInsideVisualStudio)' == 'true'">true</PackOnBuild>
 		<GetPackageContentsDependsOn>
 			AddBuiltOutput;
 			$(GetPackageContentsDependsOn)

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.csproj
@@ -187,6 +187,10 @@
       <IncludeOutputGroupsInVSIX>PackageOutputGroup</IncludeOutputGroupsInVSIX>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\Build\NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj">
+      <Project>{a3d231d7-31e4-4a70-8cd1-7246c7d069f6}</Project>
+      <Name>NuGet.Build.Packaging.Tasks</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/NuGet.Packaging.VisualStudio.targets
@@ -8,6 +8,26 @@
 		<NoGlobalAssemblyInfo>true</NoGlobalAssemblyInfo>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<!-- NOTE: this will only work if the solution was built at least once from the command line, 
+			 since the project reference below would have built the package in that case. -->
+		<Content Include="..\..\Build\NuGet.Build.Packaging.Tasks\bin\$(Configuration)\*.nupkg" 
+				 Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+			<Link>%(Filename)%(Extension)</Link>
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<!-- We can't reference the project when building from VS because that will lock the output tasks assembly -->
+		<ProjectReference Include="..\..\Build\NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj"
+						  Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+			<Project>{a3d231d7-31e4-4a70-8cd1-7246c7d069f6}</Project>
+			<Name>NuGet.Build.Packaging.Tasks</Name>
+			<AdditionalProperties>PackOnBuild=true</AdditionalProperties>
+			<IncludeOutputGroupsInVSIXLocalOnly>PackageOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+			<IncludeOutputGroupsInVSIX>PackageOutputGroup</IncludeOutputGroupsInVSIX>
+			<Private>False</Private>
+		</ProjectReference>
+	</ItemGroup>
+
 	<Target Name="GetVersion" DependsOnTargets="GitVersion" Returns="$(Version)">
 		<PropertyGroup>
 			<Version Condition=" '$(Configuration)' == 'Release' ">$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</Version>


### PR DESCRIPTION
Set PackOnBuild to the authoring tasks when building from VS.
Include previously built NuGet for build tasks when building from VS.
Include build tasks project reference for command line builds to
ensure latest version is packaged.
