### PR TITLE
Clean packaged outputs

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Authoring.Tasks/Microsoft.NuGet.Packaging.Authoring.props
+++ b/src/Build/NuGet.Build.Packaging.Authoring.Tasks/Microsoft.NuGet.Packaging.Authoring.props
@@ -10,8 +10,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-	
 	<PropertyGroup>
 		<NuGetPackaginAuthoringPropsImported>true</NuGetPackaginAuthoringPropsImported>
 	</PropertyGroup>	

--- a/src/Build/NuGet.Build.Packaging.Authoring.Tasks/NuGet.Build.Packaging.Authoring.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Authoring.Tasks/NuGet.Build.Packaging.Authoring.Tasks.targets
@@ -5,6 +5,12 @@
 		<Description>NuGet Project System Targets</Description>
 		<!-- Turn on PackOnBuild when developing the VS integration, for F5 convenience. -->
 		<PackOnBuild Condition="'$(SolutionName)' == 'NuGet.Packaging.VisualStudio' and '$(BuildingInsideVisualStudio)' == 'true'">true</PackOnBuild>
+		<!-- We add the outputs ourselves, so no need for all three below -->
+		<IncludeOutputs>false</IncludeOutputs>
+		<IncludeSymbols>false</IncludeSymbols>
+		<IncludeFrameworkReferences>false</IncludeFrameworkReferences>
+		<!-- We have a build dependency on the Build tasks, but we don't want it to become a package dependency via the synthetic project reference -->
+		<AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
 		<GetPackageContentsDependsOn>
 			AddBuiltOutput;
 			$(GetPackageContentsDependsOn)

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
@@ -11,6 +11,10 @@
 	<PropertyGroup>
 		<PackageId>NuGet.Build.Packaging</PackageId>
 		<Description>NuGet Packaging Targets</Description>
+		<!-- We add the outputs ourselves, so no need for all three below -->
+		<IncludeOutputs>false</IncludeOutputs>
+		<IncludeSymbols>false</IncludeSymbols>
+		<IncludeFrameworkReferences>false</IncludeFrameworkReferences>
 		<GetPackageContentsDependsOn>
 			AddBuiltOutput;
 			$(GetPackageContentsDependsOn)


### PR DESCRIPTION
Don't include framework references in either package.
Don't automatically include primary output or symbols
since we include those ourselves.

Finally, don't bring the Build nuget dependency to the
authoring package via MSBuild's "magic" synthetic project
reference from solution build dependency from authoring >
build tasks.
