### PR TITLE
Improve local build experience with clearer defaults

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,12 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="All" InitialTargets="Configure" TreatAsLocalProperty="RootSuffix" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="build.props" />
 
+	<PropertyGroup Condition="'$(IsCIBuild)' != 'true'">
+		<!-- Local build defaults -->
+		<Configuration Condition=" '$(Configuration)' == ''">Debug</Configuration>
+		<DeployExtension Condition=" '$(DeployExtension)' == ''">true</DeployExtension>
+		<RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(IsCIBuild)' == 'true'">
+		<Configuration Condition=" '$(Configuration)' == ''">Release</Configuration>
+		<DeployExtension Condition=" '$(DeployExtension)' == ''">false</DeployExtension>
+		<RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">true</RunCodeAnalysis>
+	</PropertyGroup>
+	
 	<PropertyGroup>
-		<Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
 		<IntermediateOutputPath>.nuget\</IntermediateOutputPath>
 		<PackagesPath>$(IntermediateOutputPath)packages</PackagesPath>
 		<Out Condition=" '$(Out)' == '' ">$(MSBuildThisFileDirectory)out</Out>
-		<CommonBuildProperties>WarningLevel=0;NoWarn=1591;RunCodeAnalysis=false;Configuration=$(Configuration);Out=$(Out);DeployExtension=false</CommonBuildProperties>
+		<CommonBuildProperties>WarningLevel=0;NoWarn=1591;Out=$(Out);Configuration=$(Configuration);DeployExtension=$(DeployExtension);RunCodeAnalysis=$(RunCodeAnalysis)</CommonBuildProperties>
 		<DefaultImportance Condition=" '$(DefaultImportance)' == '' ">high</DefaultImportance>
 	</PropertyGroup>
 

--- a/build.props
+++ b/build.props
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<PropertyGroup Condition=" '$(IsCIBuild)' == '' ">
+		<!-- If build script did not receive IsCIBuild value, try to guess it from Wrench/TeamCity/AppVeyor/MyGet/Jenkins envvars. -->
+		<IsTeamCityBuild Condition=" '$(IsTeamCityBuild)' == '' And '$(TEAMCITY_VERSION)' != '' ">true</IsTeamCityBuild>
+		<IsWrenchBuild Condition=" '$(IsWrenchBuild)' == '' And '$(BUILD_COMMAND)' != '' ">true</IsWrenchBuild>
+		<IsAppVeyorBuild Condition=" '$(IsAppVeyorBuild)' == '' And '$(APPVEYOR)' != '' ">true</IsAppVeyorBuild>
+		<IsMyGetBuild Condition=" '$(IsMyGetBuild)' == '' And '$(BuildRunner)' == 'MyGet' ">true</IsMyGetBuild>
+		<IsJenkinsBuild Condition=" '$(IsJenkinsBuild)' == '' And '$(JENKINS_URL)' != '' ">true</IsJenkinsBuild>
+
+		<IsCIBuild Condition=" '$(IsTeamCityBuild)' == 'true' Or '$(IsWrenchBuild)' == 'true' Or '$(IsAppVeyorBuild)' == 'true' Or '$(IsMyGetBuild)' == 'true' Or '$(IsJenkinsBuild)' == 'true' ">true</IsCIBuild>
+	</PropertyGroup>
+
+</Project>

--- a/src/NuGet.Build.Packaging.Shared.props
+++ b/src/NuGet.Build.Packaging.Shared.props
@@ -1,17 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-	<PropertyGroup Condition=" '$(IsCIBuild)' == '' ">
-		<!-- If build script did not receive IsCIBuild value, try to guess it from Wrench/TeamCity/AppVeyor/MyGet/Jenkins envvars. -->
-		<IsTeamCityBuild Condition=" '$(IsTeamCityBuild)' == '' And '$(TEAMCITY_VERSION)' != '' ">true</IsTeamCityBuild>
-		<IsWrenchBuild Condition=" '$(IsWrenchBuild)' == '' And '$(BUILD_COMMAND)' != '' ">true</IsWrenchBuild>
-		<IsAppVeyorBuild Condition=" '$(IsAppVeyorBuild)' == '' And '$(APPVEYOR)' != '' ">true</IsAppVeyorBuild>
-		<IsMyGetBuild Condition=" '$(IsMyGetBuild)' == '' And '$(BuildRunner)' == 'MyGet' ">true</IsMyGetBuild>
-		<IsJenkinsBuild Condition=" '$(IsJenkinsBuild)' == '' And '$(JENKINS_URL)' != '' ">true</IsJenkinsBuild>
-
-		<IsCIBuild Condition=" '$(IsTeamCityBuild)' == 'true' Or '$(IsWrenchBuild)' == 'true' Or '$(IsAppVeyorBuild)' == 'true' Or '$(IsMyGetBuild)' == 'true' Or '$(IsJenkinsBuild)' == 'true' ">true</IsCIBuild>
-	</PropertyGroup>
-
+	<Import Project="..\build.props" />
+	
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
Separate the IsCIBuild detection to a new .props, use it from
both build and solution targets, and have a more readable way
to set sefaults for both cases (local and CI builds).
