### PR TITLE
Improved UI Context and revert CanExecute for commands

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Commands.vsct
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Commands.vsct
@@ -31,7 +31,7 @@
   </CommandPlacements>
 
   <VisibilityConstraints>
-    <VisibilityItem guid="guidCommandSet" id="cmdidCreateNugetPackage" context="guidSolutionExistsAndNotBuildingAndNotDebuggingUIContext"  />
+    <VisibilityItem guid="guidCommandSet" id="cmdidCreateNugetPackage" context="guidCreateNugetPackageUIContext"  />
     <VisibilityItem guid="guidCommandSet" id="cmdidAddPlatformImplementation" context="guidAddPlatformImplementationUIContext"  />
   </VisibilityConstraints>
 
@@ -45,8 +45,8 @@
       <IDSymbol name="cmdidAddPlatformImplementation" value="0x0101" />
     </GuidSymbol>
 
+    <GuidSymbol name="guidCreateNugetPackageUIContext" value="{08E11CF6-52EE-4880-AB1B-D3CC7B10A895}" />
     <GuidSymbol name="guidAddPlatformImplementationUIContext" value="{2590DF87-84EB-487A-A1FF-160BEAF4F9CA}" />
-    <GuidSymbol name="guidSolutionExistsAndNotBuildingAndNotDebuggingUIContext" value="{D0E4DEEC-1B53-4CDA-8559-D454583AD23B}" />
   </Symbols>
 
 </CommandTable>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Commands/AddPlatformImplementationCommand.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Commands/AddPlatformImplementationCommand.cs
@@ -87,5 +87,13 @@ namespace NuGet.Packaging.VisualStudio
 				}
 			}
 		}
+
+		IProjectNode ActiveProject => solutionExplorer.Solution.ActiveProject;
+
+		protected override void CanExecute(OleMenuCommand command) =>
+			command.Enabled = command.Visible = CanExecute();
+
+		bool CanExecute() =>
+			ActiveProject.Supports(Constants.PortableClassLibraryCapability);
 	}
 }

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Constants.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Constants.cs
@@ -4,6 +4,8 @@
 
 	class Constants
 	{
+		public const string PortableClassLibraryCapability = "MultiTarget";
+
 		/// <summary>
 		/// The file extension of this project type.  No preceding period.
 		/// </summary>
@@ -16,6 +18,7 @@
 		public class UIContext
 		{
 			public const string AddPlatformImplementation = "2590DF87-84EB-487A-A1FF-160BEAF4F9CA";
+			public const string NonNuProj = "08E11CF6-52EE-4880-AB1B-D3CC7B10A895";
 		}
 
 		public class NuGet

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/NugetizerPackage.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/NugetizerPackage.cs
@@ -27,6 +27,12 @@
 		expression: "SolutionExistsAndNotBuildingAndNotDebugging & IsPortableClassLibrary",
 		termNames: new[] { "SolutionExistsAndNotBuildingAndNotDebugging", "IsPortableClassLibrary" },
 		termValues: new[] { VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_string, "ActiveProjectFlavor:786C830F-07A1-408B-BD7F-6EE04809D6DB" })]
+	[ProvideUIContextRule(
+		Constants.UIContext.NonNuProj,
+		name: "Non NuProj UI Context",
+		expression: "SolutionExistsAndNotBuildingAndNotDebugging & !IsNuProj",
+		termNames: new[] { "SolutionExistsAndNotBuildingAndNotDebugging", "IsNuProj" },
+		termValues: new[] { VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_string, "ActiveProjectCapability:PackagingProject" })]
 	[ProvideMenuResource("2000", 2)]
 	public sealed class NuGetizerPackage : Package
 	{


### PR DESCRIPTION
Since once the package is loaded, the VSCT UI Context logic is not used anymore, we need
to replicate the same logic in the commands QueryStatus impl.
