### PR TITLE
Reference assembly generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/ApiIntersect"]
+	path = external/ApiIntersect
+	url = https://github.com/xamarin/ApiInteresect.git

--- a/src/Build/Before.NuGet.Build.Packaging.sln.targets
+++ b/src/Build/Before.NuGet.Build.Packaging.sln.targets
@@ -6,5 +6,6 @@
 		<RestoreSolution Include="$(MSBuildThisFileDirectory)NuGet.Build.Packaging.Tests\Scenarios\given_a_library_with_non_nugetized_reference\b.sln" />
 		<RestoreSolution Include="$(MSBuildThisFileDirectory)NuGet.Build.Packaging.Tests\Scenarios\given_a_multi_platform_solution\forms.sln" />
 		<RestoreSolution Include="$(MSBuildThisFileDirectory)NuGet.Build.Packaging.Tests\Scenarios\given_library_with_json_dependencies\project.json" />
+		<RestoreSolution Include="$(MSBuildThisFileDirectory)..\..\external\ApiIntersect\ApiIntersect.sln" />
 	</ItemGroup>
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+using NuGet.Frameworks;
+
+namespace NuGet.Build.Packaging.Tasks
+{
+	public class ApiIntersect : ToolTask
+	{
+		[Required]
+		public ITaskItem Framework { get; set; }
+
+		[Required]
+		public ITaskItem[] IntersectionAssembly { get; set; }
+
+		[Required]
+		public ITaskItem RootOutputDirectory { get; set; }
+
+		[Output]
+		public ITaskItem OutputDirectory { get; set; }
+
+		protected override string ToolName
+		{
+			get { return "ApiIntersect"; }
+		}
+
+		protected override string GenerateFullPathToTool()
+		{
+			return Path.Combine(ToolPath, ToolExe);
+		}
+
+		protected override MessageImportance StandardErrorLoggingImportance
+		{
+			get { return MessageImportance.High; }
+		}
+
+		protected override string GenerateCommandLineCommands()
+		{
+			var builder = new CommandLineBuilder();
+
+			var nugetFramework = NuGetFramework.Parse(Framework.ItemSpec);
+
+			builder.AppendSwitch("-o");
+			CreateOutputDirectoryItem(nugetFramework);
+			builder.AppendFileNameIfNotNull(OutputDirectory.ItemSpec);
+
+			string frameworkPath = GetFrameworkPath(nugetFramework);
+			builder.AppendSwitch("-f");
+			builder.AppendFileNameIfNotNull(frameworkPath);
+
+			foreach (var assembly in IntersectionAssembly.NullAsEmpty())
+			{
+				builder.AppendSwitch("-i");
+				builder.AppendFileNameIfNotNull(assembly.ItemSpec);
+			}
+
+			return builder.ToString();
+		}
+
+		void CreateOutputDirectoryItem(NuGetFramework framework)
+		{
+			string fullOutputPath = Path.Combine(RootOutputDirectory.ItemSpec, GetOutputDirectoryName(framework));
+			OutputDirectory = new TaskItem(fullOutputPath + Path.DirectorySeparatorChar);
+			OutputDirectory.SetMetadata("TargetFrameworkVersion", "v" + framework.Version.ToString(2));
+			OutputDirectory.SetMetadata("TargetFrameworkProfile", framework.Profile);
+			OutputDirectory.SetMetadata(MetadataName.TargetFrameworkMoniker, Framework.ItemSpec);
+		}
+
+		string GetFrameworkPath(NuGetFramework framework)
+		{
+			if (framework.IsPCL)
+			{
+				return GetPortableLibraryPath(framework);
+			}
+
+			throw new NotImplementedException("Only PCL profiles supported.");
+		}
+
+		string GetPortableLibraryPath(NuGetFramework framework)
+		{
+			return Path.Combine(
+				GetPortableRootDirectory(),
+				"v" + framework.Version.ToString(2),
+				"Profile",
+				framework.Profile);
+		}
+
+		static string GetPortableRootDirectory()
+		{
+			if (RuntimeEnvironmentHelper.IsMono)
+			{
+				string macPath = "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETPortable/";
+				if (Directory.Exists(macPath))
+					return macPath;
+
+				return Path.Combine(Path.GetDirectoryName(typeof(Object).Assembly.Location), "../xbuild-frameworks/.NETPortable/");
+			}
+
+			return Path.Combine(
+				Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify),
+				@"Reference Assemblies\Microsoft\Framework\.NETPortable");
+		}
+
+		string GetOutputDirectoryName(NuGetFramework framework)
+		{
+			if (framework.IsPCL && framework.HasProfile)
+			{
+				return framework.Profile;
+			}
+
+			return framework.GetShortFolderName();
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -61,7 +61,7 @@ namespace NuGet.Build.Packaging.Tasks
 
 		void CreateOutputDirectoryItem(NuGetFramework framework)
 		{
-			string fullOutputPath = Path.Combine(RootOutputDirectory.ItemSpec, GetOutputDirectoryName(framework));
+			string fullOutputPath = GetApiIntersectTargetPaths.GetOutputDirectory(RootOutputDirectory.ItemSpec, framework);
 			OutputDirectory = new TaskItem(fullOutputPath + Path.DirectorySeparatorChar);
 			OutputDirectory.SetMetadata("TargetFrameworkVersion", "v" + framework.Version.ToString(2));
 			OutputDirectory.SetMetadata("TargetFrameworkProfile", framework.Profile);
@@ -101,16 +101,6 @@ namespace NuGet.Build.Packaging.Tasks
 			return Path.Combine(
 				Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify),
 				@"Reference Assemblies\Microsoft\Framework\.NETPortable");
-		}
-
-		string GetOutputDirectoryName(NuGetFramework framework)
-		{
-			if (framework.IsPCL && framework.HasProfile)
-			{
-				return framework.Profile;
-			}
-
-			return framework.GetShortFolderName();
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
@@ -95,5 +95,8 @@ namespace NuGet.Build.Packaging
 
 		public static void LogErrorCode(this TaskLoggingHelper log, string code, string message, params object[] messageArgs) =>
 			log.LogError(string.Empty, code, string.Empty, string.Empty, 0, 0, 0, 0, message, messageArgs);
+
+		public static void LogWarningCode(this TaskLoggingHelper log, string code, string file, string message, params object[] messageArgs) =>
+			log.LogWarning(string.Empty, code, string.Empty, file, 0, 0, 0, 0, message, messageArgs);
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tasks/GenerateAssemblyInfo.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GenerateAssemblyInfo.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace NuGet.Build.Packaging.Tasks
+{
+	public class GenerateAssemblyInfo : Task
+	{
+		[Required]
+		public ITaskItem[] Assemblies { get; set; }
+
+		[Required]
+		public ITaskItem[] OutputDirectories { get; set; }
+
+		[Output]
+		public string AssemblyName { get; set; }
+
+		public override bool Execute()
+		{
+			AssemblyName name = GetAssemblyName();
+			CreateAssemblyInfo(name);
+
+			AssemblyName = name.Name;
+
+			return true;
+		}
+
+		AssemblyName GetAssemblyName()
+		{
+			AssemblyName[] assemblyNames = Assemblies.NullAsEmpty()
+				.Select(assembly => System.Reflection.AssemblyName.GetAssemblyName(assembly.ItemSpec))
+				.ToArray();
+
+			string[] allNames = assemblyNames.Select(name => name.Name).ToArray();
+			if (allNames.Distinct().Count() > 1)
+			{
+				Log.LogWarning("Assembly names should be the same for a bait and switch NuGet package. Names: '{0}' Assemblies: {1}",
+					string.Join(", ", allNames),
+					string.Join(", ", Assemblies.Select(assembly => assembly.ItemSpec)));
+			}
+
+			Version[] allVersions = assemblyNames.Select(name => name.Version).ToArray();
+			if (allVersions.Distinct().Count() > 1)
+			{
+				Log.LogWarning("Assembly versions should be the same for a bait and switch NuGet package. Versions: '{0}' Assemblies: {1}",
+					string.Join(", ", allVersions.Select(version => version.ToString())),
+					string.Join(", ", Assemblies.Select(assembly => assembly.ItemSpec)));
+			}
+
+			return assemblyNames.FirstOrDefault();
+		}
+
+		void CreateAssemblyInfo(AssemblyName assemblyName)
+		{
+			string text = "using System.Reflection;" + Environment.NewLine +
+				string.Format("[assembly: AssemblyVersion (\"{0}\")]", assemblyName.Version);
+
+			foreach (ITaskItem directory in OutputDirectories.NullAsEmpty())
+			{
+				string fileName = Path.Combine(directory.ItemSpec, "AssemblyInfo.cs");
+				File.WriteAllText(fileName, text);
+			}
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tasks/GenerateAssemblyInfo.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GenerateAssemblyInfo.cs
@@ -37,7 +37,9 @@ namespace NuGet.Build.Packaging.Tasks
 			string[] allNames = assemblyNames.Select(name => name.Name).ToArray();
 			if (allNames.Distinct().Count() > 1)
 			{
-				Log.LogWarning("Assembly names should be the same for a bait and switch NuGet package. Names: '{0}' Assemblies: {1}",
+				Log.LogWarningCode("NG1003",
+					BuildEngine.ProjectFileOfTaskNode,
+					"Assembly names should be the same for a bait and switch NuGet package. Names: '{0}' Assemblies: {1}",
 					string.Join(", ", allNames),
 					string.Join(", ", Assemblies.Select(assembly => assembly.ItemSpec)));
 			}
@@ -45,7 +47,9 @@ namespace NuGet.Build.Packaging.Tasks
 			Version[] allVersions = assemblyNames.Select(name => name.Version).ToArray();
 			if (allVersions.Distinct().Count() > 1)
 			{
-				Log.LogWarning("Assembly versions should be the same for a bait and switch NuGet package. Versions: '{0}' Assemblies: {1}",
+				Log.LogWarningCode("NG1004",
+					BuildEngine.ProjectFileOfTaskNode,
+					"Assembly versions should be the same for a bait and switch NuGet package. Versions: '{0}' Assemblies: {1}",
 					string.Join(", ", allVersions.Select(version => version.ToString())),
 					string.Join(", ", Assemblies.Select(assembly => assembly.ItemSpec)));
 			}

--- a/src/Build/NuGet.Build.Packaging.Tasks/GenerateReferenceAssembly.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GenerateReferenceAssembly.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9886C7D1-0610-4292-9E13-94EC012D0900}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <UseMSBuildEngine>true</UseMSBuildEngine>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+
+  <PropertyGroup>
+    <PrepareResourcesDependsOn>
+      _CollectCompileFiles;
+      $(PrepareResourcesDependsOn)
+    </PrepareResourcesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CollectCompileFiles">
+    <!-- use property function since ** returns the same file twice with xbuild resulting in a compile warning. -->
+    <PropertyGroup>
+      <_CompileFiles>$([System.IO.Directory]::GetFiles('$(SrcDir)Contract\', '*.cs', SearchOption.AllDirectories))</_CompileFiles>
+    </PropertyGroup>
+    <ItemGroup>
+      <Compile Include="$(_CompileFiles)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/GenerateReferenceAssembly.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GenerateReferenceAssembly.csproj
@@ -33,12 +33,8 @@
   </PropertyGroup>
 
   <Target Name="_CollectCompileFiles">
-    <!-- use property function since ** returns the same file twice with xbuild resulting in a compile warning. -->
-    <PropertyGroup>
-      <_CompileFiles>$([System.IO.Directory]::GetFiles('$(SrcDir)Contract\', '*.cs', SearchOption.AllDirectories))</_CompileFiles>
-    </PropertyGroup>
     <ItemGroup>
-      <Compile Include="$(_CompileFiles)" />
+      <Compile Include="$(SrcDir)Contract\**\*.cs" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/GetApiIntersectTargetPaths.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GetApiIntersectTargetPaths.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+
+namespace NuGet.Build.Packaging.Tasks
+{
+	public class GetApiIntersectTargetPaths : Task
+	{
+		[Required]
+		public ITaskItem[] Frameworks { get; set; }
+
+		[Required]
+		public ITaskItem[] Assemblies { get; set; }
+
+		[Required]
+		public ITaskItem RootOutputDirectory { get; set; }
+
+		[Output]
+		public ITaskItem[] TargetPaths { get; set; }
+
+		public override bool Execute()
+		{
+			string assemblyFileName = GetAssemblyFileName();
+
+			TargetPaths = Frameworks.NullAsEmpty()
+				.Select(framework => GetTargetPath(framework, assemblyFileName))
+				.ToArray();
+
+			return true;
+		}
+
+		string GetAssemblyFileName()
+		{
+			return Assemblies.NullAsEmpty()
+				.Select(assembly => Path.GetFileName(assembly.ItemSpec))
+				.FirstOrDefault();
+		}
+
+		private ITaskItem GetTargetPath(ITaskItem framework, string assemblyFileName)
+		{
+			var nugetFramework = NuGetFramework.Parse(framework.ItemSpec);
+			string outputDirectory = GetOutputDirectory(RootOutputDirectory.ItemSpec, nugetFramework);
+
+			string outputPath = Path.Combine(outputDirectory, "bin", assemblyFileName);
+
+			var item = new TaskItem(outputPath);
+			item.SetMetadata(MetadataName.TargetFrameworkMoniker, framework.ItemSpec);
+
+			return item;
+		}
+
+		internal static string GetOutputDirectory(string rootDirectory, NuGetFramework framework)
+		{
+			return Path.Combine(rootDirectory, GetOutputDirectoryName(framework));
+		}
+
+		static string GetOutputDirectoryName(NuGetFramework framework)
+		{
+			if (framework.IsPCL && framework.HasProfile)
+			{
+				return framework.Profile;
+			}
+
+			return framework.GetShortFolderName();
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tasks/GetApiIntersectTargetPaths.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/GetApiIntersectTargetPaths.cs
@@ -35,9 +35,20 @@ namespace NuGet.Build.Packaging.Tasks
 
 		string GetAssemblyFileName()
 		{
-			return Assemblies.NullAsEmpty()
+			string[] fileNames = Assemblies.NullAsEmpty()
 				.Select(assembly => Path.GetFileName(assembly.ItemSpec))
-				.FirstOrDefault();
+				.ToArray();
+
+			if (fileNames.Distinct().Count() > 1)
+			{
+				Log.LogWarningCode("NG1003",
+					BuildEngine.ProjectFileOfTaskNode,
+					"Assembly names should be the same for a bait and switch NuGet package. Names: '{0}' Assemblies: {1}",
+					string.Join(", ", fileNames),
+					string.Join(", ", Assemblies.Select(assembly => assembly.ItemSpec)));
+			}
+
+			return fileNames.FirstOrDefault();
 		}
 
 		private ITaskItem GetTargetPath(ITaskItem framework, string assemblyFileName)

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -29,6 +29,10 @@
     <Content Include="NuGet.Build.Packaging.Authoring.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="..\..\..\external\ApiIntersect\ApiIntersect\app.config">
+      <Link>ApiIntersect.exe.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="NuGet.Build.Packaging.Version.props">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -39,9 +43,17 @@
     <Content Include="NuGet.Build.Packaging.Authoring.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="GenerateReferenceAssembly.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\external\ApiIntersect\ApiIntersect\ApiIntersect.csproj">
+      <Project>{cd767d93-6c99-4d6a-a303-3c139a73400e}</Project>
+      <Name>ApiIntersect</Name>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
@@ -49,9 +61,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApiIntersect.cs" />
     <Compile Include="AssignPackagePath.cs" />
     <Compile Include="CreatePackage.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="GenerateAssemblyInfo.cs" />
     <Compile Include="MetadataName.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -66,6 +66,7 @@
     <Compile Include="CreatePackage.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="GenerateAssemblyInfo.cs" />
+    <Compile Include="GetApiIntersectTargetPaths.cs" />
     <Compile Include="MetadataName.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
@@ -15,6 +15,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<IsPackagingProject Condition="'$(IsPackagingProject)' == '' and '$(MSBuildProjectExtension)' == '.nuproj'">true</IsPackagingProject>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<ApiIntersectToolPath Condition=" '$(ApiIntersectTool)' == '' ">$(MSBuildThisFileDirectory)</ApiIntersectToolPath>
+		<ApiIntersectToolExe Condition=" '$(ApiIntersectToolExe)' == '' ">ApiIntersect.exe</ApiIntersectToolExe>
+	</PropertyGroup>
+
 	<ItemDefinitionGroup>
 		<PackageFile>
 			<!-- See @(PackageItemKind) below -->

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -676,7 +676,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_GenerateReferenceAssemblies" DependsOnTargets="_GetReferenceAssemblyTargetPaths" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
+	<Target Name="_GenerateReferenceAssemblies"
+		DependsOnTargets="_GetReferenceAssemblyTargetPaths"
+		Condition=" '@(ReferenceAssemblyFramework)' != '' "
+		Inputs="@(IntersectionAssembly)"
+		Outputs="@(_ReferenceAssemblyTargetPath)">
+
 		<ApiIntersect
 			Framework="%(ReferenceAssemblyFramework.Identity)"
 			RootOutputDirectory="$(IntermediateOutputPath)"

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -14,6 +14,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.CreatePackage" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.ReadLegacyJsonDependencies" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.ReadLegacyConfigDependencies" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
+	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.ApiIntersect" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
+	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.GenerateAssemblyInfo" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 
 	<Import Project="NuGet.Build.Packaging.props" Condition="'$(NuGetBuildPackagingPropsImported)' == ''" />
 
@@ -201,6 +203,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
 			$(GetPackageContentsDependsOn)
 			_CollectMissingIsPackableProjectReferencesOutputs;
+			_GenerateReferenceAssemblies;
 		</GetPackageContentsDependsOn>
 	</PropertyGroup>
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
@@ -638,6 +641,63 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</CreatePackage>
 
 		<Message Importance="high" Text="Created package at %(_PackageTargetPath.FullPath)." />
+	</Target>
+
+
+	<PropertyGroup>
+		<CleanDependsOn>$(CleanDependsOn);_CleanReferenceAssemblyIntermediateOutputs</CleanDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_GenerateReferenceAssemblies" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
+		<MSBuild
+			Projects="@(_IsPackableProject)"
+			Targets="GetTargetPath">
+			<Output TaskParameter="TargetOutputs" ItemName="IntersectionAssembly" />
+		</MSBuild>
+
+		<ApiIntersect
+			Framework="%(ReferenceAssemblyFramework.Identity)"
+			RootOutputDirectory="$(IntermediateOutputPath)"
+			IntersectionAssembly="@(IntersectionAssembly)"
+			ToolPath="$(ApiIntersectToolPath)"
+			ToolExe="$(ApiIntersectToolExe)">
+			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />
+		</ApiIntersect>
+
+		<GenerateAssemblyInfo
+			Assemblies="@(IntersectionAssembly)"
+			OutputDirectories="@(_ReferenceAssemblyBuildInfo->'%(Identity)Contract')">
+			<Output TaskParameter="AssemblyName" PropertyName="_ReferenceAssemblyName" />
+		</GenerateAssemblyInfo>
+
+		<MSBuild
+			Projects="$(MSBuildThisFileDirectory)GenerateReferenceAssembly.csproj"
+			Properties="
+				AssemblyName=$(_ReferenceAssemblyName);
+				SrcDir=%(_ReferenceAssemblyBuildInfo.FullPath);
+				OutputPath=%(_ReferenceAssemblyBuildInfo.FullPath)bin\;
+				IntermediateOutputPath=%(_ReferenceAssemblyBuildInfo.FullPath)obj\;
+				TargetFrameworkVersion=%(_ReferenceAssemblyBuildInfo.TargetFrameworkVersion);
+				TargetFrameworkProfile=%(_ReferenceAssemblyBuildInfo.TargetFrameworkProfile)" />
+
+		<ItemGroup>
+			<PackageFile Include="@(_ReferenceAssemblyBuildInfo->'%(Identity)bin\$(_ReferenceAssemblyName).dll')">
+				<Kind>Lib</Kind>
+				<TargetFrameworkMoniker>%(_ReferenceAssemblyBuildInfo.TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</PackageFile>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_CleanReferenceAssemblyIntermediateOutputs" Condition=" '@(ReferenceAssemblyFramework)' != '' and Exists('$(IntermediateOutputPath)') ">
+		<PropertyGroup>
+			<_ReferenceAssemblyIntermediateOutputDirectories>$([System.IO.Directory]::GetDirectories('$(IntermediateOutputPath)'))</_ReferenceAssemblyIntermediateOutputDirectories>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<_ReferenceAssemblyIntermediateOutputDirectory Include="$(_ReferenceAssemblyIntermediateOutputDirectories)" />
+		</ItemGroup>
+
+		<RemoveDir Directories="@(_ReferenceAssemblyIntermediateOutputDirectory)" />
 	</Target>
 
 	<Import Project="NuGet.Build.Packaging.Authoring.targets" Condition="'$(IsPackagingProject)' == 'true'" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -16,6 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.ReadLegacyConfigDependencies" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.ApiIntersect" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.GenerateAssemblyInfo" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
+	<UsingTask TaskName="NuGet.Build.Packaging.Tasks.GetApiIntersectTargetPaths" AssemblyFile="NuGet.Build.Packaging.Tasks.dll" />
 
 	<Import Project="NuGet.Build.Packaging.props" Condition="'$(NuGetBuildPackagingPropsImported)' == ''" />
 
@@ -203,7 +204,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
 			$(GetPackageContentsDependsOn)
 			_CollectMissingIsPackableProjectReferencesOutputs;
-			_GenerateReferenceAssemblies;
+			_GetReferenceAssemblyTargetPaths;
 		</GetPackageContentsDependsOn>
 	</PropertyGroup>
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
@@ -620,6 +621,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			$(PackDependsOn)
 			GetPackageTargetPath;
 			GetPackageContents;
+			_GenerateReferenceAssemblies;
 		</PackDependsOn>
 	</PropertyGroup>
 
@@ -648,7 +650,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<CleanDependsOn>$(CleanDependsOn);_CleanReferenceAssemblyIntermediateOutputs</CleanDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_GenerateReferenceAssemblies" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
+	<Target Name="_GetReferenceAssemblyTargetPaths" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
 		<ItemGroup>
 			<_ReferenceAssemblyProjects Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false'" />
 		</ItemGroup>
@@ -659,6 +661,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<Output TaskParameter="TargetOutputs" ItemName="IntersectionAssembly" />
 		</MSBuild>
 
+		<GetApiIntersectTargetPaths
+			Frameworks="%(ReferenceAssemblyFramework.Identity)"
+			RootOutputDirectory="$(IntermediateOutputPath)"
+			Assemblies="@(IntersectionAssembly)">
+			<Output TaskParameter="TargetPaths" ItemName="_ReferenceAssemblyTargetPath" />
+		</GetApiIntersectTargetPaths>
+
+		<ItemGroup>
+			<PackageFile Include="@(_ReferenceAssemblyTargetPath)">
+				<Kind>Lib</Kind>
+				<TargetFrameworkMoniker>%(_ReferenceAssemblyTargetPath.TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</PackageFile>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_GenerateReferenceAssemblies" DependsOnTargets="_GetReferenceAssemblyTargetPaths" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
 		<ApiIntersect
 			Framework="%(ReferenceAssemblyFramework.Identity)"
 			RootOutputDirectory="$(IntermediateOutputPath)"
@@ -683,13 +701,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 				IntermediateOutputPath=%(_ReferenceAssemblyBuildInfo.FullPath)obj\;
 				TargetFrameworkVersion=%(_ReferenceAssemblyBuildInfo.TargetFrameworkVersion);
 				TargetFrameworkProfile=%(_ReferenceAssemblyBuildInfo.TargetFrameworkProfile)" />
-
-		<ItemGroup>
-			<PackageFile Include="@(_ReferenceAssemblyBuildInfo->'%(Identity)bin\$(_ReferenceAssemblyName).dll')">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker>%(_ReferenceAssemblyBuildInfo.TargetFrameworkMoniker)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
 	</Target>
 
 	<Target Name="_CleanReferenceAssemblyIntermediateOutputs" Condition=" '@(ReferenceAssemblyFramework)' != '' and Exists('$(IntermediateOutputPath)') ">

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -649,8 +649,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_GenerateReferenceAssemblies" Condition=" '@(ReferenceAssemblyFramework)' != '' ">
+		<ItemGroup>
+			<_ReferenceAssemblyProjects Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false'" />
+		</ItemGroup>
+
 		<MSBuild
-			Projects="@(_IsPackableProject)"
+			Projects="@(_ReferenceAssemblyProjects)"
 			Targets="GetTargetPath">
 			<Output TaskParameter="TargetOutputs" ItemName="IntersectionAssembly" />
 		</MSBuild>

--- a/src/Build/NuGet.Build.Packaging.Tests/GetApiIntersectTargetPathsTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/GetApiIntersectTargetPathsTests.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Build.Packaging.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Build.Packaging
+{
+	public class GetApiIntersectTargetPathsTests
+	{
+		ITestOutputHelper output;
+		MockBuildEngine engine;
+		GetApiIntersectTargetPaths task;
+
+		public GetApiIntersectTargetPathsTests(ITestOutputHelper output)
+		{
+			this.output = output;
+			engine = new MockBuildEngine(output);
+			task = new GetApiIntersectTargetPaths
+			{
+				BuildEngine = engine
+			};
+		}
+
+		[Fact]
+		public void when_framework_is_profile_78_then_target_path_returned()
+		{
+			task.RootOutputDirectory = new TaskItem(Path.Combine("project", "obj", "Debug"));
+			task.Frameworks = new[]
+			{
+				new TaskItem(".NETPortable,Version=v4.5,Profile=Profile78")
+			};
+			task.Assemblies = new[]
+			{
+				new TaskItem(Path.Combine("Android", "test.dll")),
+				new TaskItem(Path.Combine("iOS", "test.dll"))
+			};
+
+			bool result = task.Execute();
+
+			string expectedTargetPath = Path.Combine("project", "obj", "Debug", "Profile78", "bin", "test.dll");
+			Assert.True(result);
+			Assert.Equal(1, task.TargetPaths.Length);
+			Assert.Equal(expectedTargetPath, task.TargetPaths[0].ItemSpec);
+		}
+
+		[Fact]
+		public void when_assembly_filenames_do_not_match_then_warning_logged()
+		{
+			task.RootOutputDirectory = new TaskItem(Path.Combine("project", "obj", "Debug"));
+			task.Frameworks = new[]
+			{
+				new TaskItem(".NETPortable,Version=v4.5,Profile=Profile78")
+			};
+			task.Assemblies = new[]
+			{
+				new TaskItem(Path.Combine("Android", "Test.Android.dll")),
+				new TaskItem(Path.Combine("iOS", "Test.iOS.dll"))
+			};
+
+			task.Execute();
+
+			string expectedMessage = string.Format("Assembly names should be the same for a bait and switch NuGet package. Names: 'Test.Android.dll, Test.iOS.dll' Assemblies: {0}, {1}",
+				task.Assemblies[0].ItemSpec,
+				task.Assemblies[1].ItemSpec);
+			var warningEvent = engine.LoggedWarningEvents[0];
+			Assert.Equal(1, engine.LoggedWarningEvents.Count);
+			Assert.Equal("NG1003", warningEvent.Code);
+			Assert.Equal(expectedMessage, warningEvent.Message);
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -61,6 +61,8 @@
     <Content Include="Scenarios\given_a_multi_platform_solution\net\forms.net46.csproj" />
     <Content Include="Scenarios\given_a_multi_platform_solution\pcl\forms.pcl.csproj" />
     <Content Include="Scenarios\given_a_packaging_project\e.csproj" />
+    <Content Include="Scenarios\given_a_packaging_project_with_reference_assembly\b.sln" />
+    <Content Include="Scenarios\given_a_packaging_project_with_reference_assembly\b\b.csproj" />
     <Content Include="Scenarios\given_library_with_config_dependencies\a.csproj" />
     <Content Include="Scenarios\given_library_with_config_dependencies\a.sln" />
     <Content Include="Scenarios\given_library_with_json_dependencies\project.json" />
@@ -72,6 +74,7 @@
     <None Include="Scenarios\given_a_library_with_non_nugetized_reference\b\project.lock.json" />
     <Content Include="Scenarios\given_a_multi_platform_solution\pcl\project.json" />
     <Content Include="Scenarios\given_a_multi_platform_solution\pcl\project.lock.json" />
+    <Content Include="Scenarios\given_a_packaging_project_with_reference_assembly\a.nuproj" />
     <None Include="Scenarios\given_library_with_config_dependencies\packages.config" />
     <None Include="Scenarios\Scenario.props" />
     <None Include="Scenarios\Scenario.targets" />
@@ -97,6 +100,7 @@
     <Compile Include="given_a_localized_library.cs" />
     <Compile Include="given_a_complex_pack.cs" />
     <Compile Include="given_a_library_with_non_nugetized_reference.cs" />
+    <Compile Include="given_a_packaging_project_with_reference_assembly.cs" />
     <Compile Include="given_library_with_config_dependencies.cs" />
     <Compile Include="given_library_with_json_dependencies.cs" />
     <Compile Include="given_an_empty_library_project.cs" />
@@ -107,6 +111,7 @@
     <Content Include="Scenarios\given_a_multi_platform_solution\android\quickstart\sample.vb" />
     <Compile Include="ReadLegacyJsonDependenciesTests.cs" />
     <Compile Include="ReadLegacyConfigDependenciesTests.cs" />
+    <Content Include="Scenarios\given_a_packaging_project_with_reference_assembly\b\MyClass.cs" />
     <Compile Include="UtilitiesTests.cs" />
     <Compile Include="Utilities\FrameworkAssemblyReferenceComparer.cs" />
     <Compile Include="Utilities\ManifestContentFilesComparer.cs" />
@@ -120,6 +125,10 @@
     <Compile Include="Utilities\TestOutputLogger.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\external\ApiIntersect\ApiIntersect\ApiIntersect.csproj">
+      <Project>{cd767d93-6c99-4d6a-a303-3c139a73400e}</Project>
+      <Name>ApiIntersect</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj">
       <Project>{a3d231d7-31e4-4a70-8cd1-7246c7d069f6}</Project>
       <Name>NuGet.Build.Packaging.Tasks</Name>

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Builder.NuGetizer.cs">
       <DependentUpon>Builder.cs</DependentUpon>
     </Compile>
+    <Compile Include="GetApiIntersectTargetPathsTests.cs" />
     <Compile Include="given_a_packaging_project.cs" />
     <Compile Include="given_a_multi_platform_solution.cs" />
     <Compile Include="given_a_library_with_content.cs" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/a.nuproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/a.nuproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+		<PackageId>a.package</PackageId>
+		<PackageVersion>1.0.0</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="b\b.csproj">
+			<Project>$(GuidB)</Project>
+			<Name>b</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ReferenceAssemblyFramework Include=".NETPortable,Version=v4.5,Profile=Profile259" />
+	</ItemGroup>
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />	
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b.sln
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "b", "b\b.csproj", "{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}"
+EndProject
+Project("{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}") = "a", "a.nuproj", "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/MyClass.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/MyClass.cs
@@ -1,0 +1,7 @@
+
+namespace b
+{
+    public class MyClass
+    {
+    }
+}

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/b.csproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.props))\Scenario.props" />
+	<PropertyGroup>
+		<ProjectGuid>$(GuidB)</ProjectGuid>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+		<DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Include="MyClass.cs" />
+	</ItemGroup>
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project_with_reference_assembly.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project_with_reference_assembly.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using NuGet.Build.Packaging.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.Build.Packaging
+{
+	public class given_a_packaging_project_with_reference_assembly
+	{
+		ITestOutputHelper output;
+
+		public given_a_packaging_project_with_reference_assembly(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public void when_getting_contents_then_includes_reference_assembly()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project_with_reference_assembly), target: "GetPackageContents", output: output);
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\portable45-net45+win8+wp8+wpa81\b.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = PackageItemKind.Lib,
+				Identity = @"obj\a\Profile259\bin\b.dll",
+			}));
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = @"lib\net46\b.dll",
+			}));
+		}
+	}
+}

--- a/src/Build/NuGet.Build.Packaging.sln
+++ b/src/Build/NuGet.Build.Packaging.sln
@@ -19,20 +19,40 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Build.Packaging.Tests", "NuGet.Build.Packaging.Tests\NuGet.Build.Packaging.Tests.csproj", "{212952C3-22F5-4263-BF9B-B17316B3B3CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiIntersect", "..\..\external\ApiIntersect\ApiIntersect\ApiIntersect.csproj", "{CD767D93-6C99-4D6A-A303-3C139A73400E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Debug|x86.Build.0 = Debug|Any CPU
 		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}.Release|x86.Build.0 = Release|Any CPU
 		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Debug|x86.Build.0 = Debug|Any CPU
 		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{212952C3-22F5-4263-BF9B-B17316B3B3CA}.Release|x86.Build.0 = Release|Any CPU
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|Any CPU.Build.0 = Debug|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|x86.ActiveCfg = Debug|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|x86.Build.0 = Debug|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|Any CPU.ActiveCfg = Release|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|Any CPU.Build.0 = Release|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|x86.ActiveCfg = Release|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Support generating reference assemblies for PCL profiles.

Add a ReferenceAssemblyFramework item to a NuGet packaging project (.nuproj):

```
<ItemGroup>
    <ReferenceAssemblyFramework Include=".NETPortable,Version=v4.5,Profile=Profile259" />
</ItemGroup>
```

Then building the .nuproj will run the ApiIntersect tool against the referenced projects and generate a reference assembly that is included in the NuGet package.
