### PR TITLE
Simplify package file kind by removing doc/symbols concepts

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.props
@@ -37,15 +37,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<ItemGroup>
 		<!-- Default mapping between %(PackageFile.Kind) metadata and package folders inside .nupkg -->
 		<!-- PackageFolder should map to a supported folder as defined in PackagingConstants.Folders -->
-		<PackageItemKind Include="Library">
-			<PackageFolder>lib</PackageFolder>
-		</PackageItemKind>
-		<PackageItemKind Include="Symbols">
-			<PackageFolder>lib</PackageFolder>
-		</PackageItemKind>
-		<PackageItemKind Include="Doc">
-			<PackageFolder>lib</PackageFolder>
-		</PackageItemKind>
 		<PackageItemKind Include="Content">
 			<!-- Plain "content" is deprecated as of NuGet v3+ -->
 			<PackageFolder>contentFiles</PackageFolder>
@@ -124,6 +115,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</ItemGroup>
 
 	<PropertyGroup>
+		<!-- Flag this project as having been "nugetized" -->
+		<IsNuGetized>true</IsNuGetized>
 		<NuGetBuildPackagingPropsImported>true</NuGetBuildPackagingPropsImported>
 	</PropertyGroup>
 

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -21,6 +21,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<Import Project="NuGet.Build.Packaging.props" Condition="'$(NuGetBuildPackagingPropsImported)' == ''" />
 
 	<PropertyGroup>
+		<!-- The Kind of primary output (build, symbols and doc) set if IncludeOutputsInPackage = true -->
+		<PrimaryOutputPackageFileKind Condition="'$(PrimaryOutputPackageFileKind)' == ''">Lib</PrimaryOutputPackageFileKind>
+		
 		<!-- Infer PackageRererence elements from packages.config/project.json files in the project -->
 		<InferLegacyPackageReferences Condition="'$(InferLegacyPackageReferences)' == ''">true</InferLegacyPackageReferences>
 		<!-- Whether to include @(Content) items in the package -->
@@ -49,12 +52,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 	<ItemGroup>
 		<ProjectCapability Include="Packable" Condition="'$(IsPackable)' == 'true'"/>
+		
+		<!-- Converts potentially multiple $(ReferenceAssemblyFrameworks) into @(ReferenceAssemblyFramework) -->
+		<ReferenceAssemblyFramework Include="$(ReferenceAssemblyFrameworks)" Condition="'$(ReferenceAssemblyFrameworks)' != ''" />
 	</ItemGroup>
 
 	<!-- Extends the built-in GetTargetPath output to signal that the project has been nugetized -->
 	<ItemDefinitionGroup>
 		<TargetPathWithTargetPlatformMoniker>
 			<IsPackable>$(IsPackable)</IsPackable>
+			<IsNuGetized>$(IsNuGetized)</IsNuGetized>
 		</TargetPathWithTargetPlatformMoniker>
 	</ItemDefinitionGroup>
 
@@ -216,7 +223,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                          Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary output -->
-				<Kind>Lib</Kind>
+				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<!-- Remove when https://github.com/Microsoft/msbuild/pull/1076 ships -->
@@ -227,20 +234,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<PackageFile Include="@(_DocumentationProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                          Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary docs -->
-				<Kind>Doc</Kind>
+				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<PackageFile Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                          Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IncludeSymbolsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary symbols -->
-				<Kind>Symbols</Kind>
+				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<!-- Change to %(FinalOutputPath) when https://github.com/Microsoft/msbuild/pull/1115 ships -->
 			<PackageFile Include="@(SatelliteDllsProjectOutputGroupOutput -> '%(FullPath)')"
 						 Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute satellite dlls -->
-				<Kind>Lib</Kind>
+				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<!-- NOTE: Content is opt-out (must have IncludeInPackage=false to exclude) -->
@@ -279,6 +286,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup>
 			<PackageFile>
 				<PackageId>$(PackageId)</PackageId>
+				<Platform>$(Platform)</Platform>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
 			</PackageFile>
 		</ItemGroup>
@@ -325,9 +333,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
 				<!-- Only do this for Library assets that come from project references that don't build nugets (PackageId=='' above) -->
 				<TargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Library' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Symbols' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Doc'"></TargetFramework>
+											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib'"></TargetFramework>
 				<!-- NOTE: we're always overwriting the TFM in this case since 
 					 this item will end up making up the contents of this package 
 					 project in its current TFM configuration. 
@@ -346,9 +352,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
 				<!-- Only do this for Library assets that come from project references that don't build nugets (PackageId=='' above) -->
 				<TargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Library' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Symbols' or 
-											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Doc'"></TargetFramework>
+											'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib'"></TargetFramework>
 				<TargetFrameworkMoniker>%(OriginalTargetFrameworkMoniker)</TargetFrameworkMoniker>
 			</_ReferencedPackageContentWithOriginalValues>
 		</ItemGroup>
@@ -468,7 +472,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 		<ItemGroup>
 			<PackageFile Include="@(_ReferencedProjectDebugSymbols -> '%(FinalOutputPath)')">
-				<Kind>Symbols</Kind>
+				<Kind>Lib</Kind>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
 			</PackageFile>
 		</ItemGroup>
@@ -485,7 +489,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup>
 			<PackageFile Include="@(_ReferencedProjectOutputDependencySymbols -> '%(FullPath)')"
 						 Condition="'%(_ReferencedProjectOutputDependencySymbols.CopyLocal)' == 'true'">
-				<Kind>Symbols</Kind>
+				<Kind>Lib</Kind>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
 			</PackageFile>
 		</ItemGroup>
@@ -508,7 +512,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<FinalFullOutputPath Condition="$([System.IO.Path]::IsPathRooted('%(_ReferencedProjectDocumentation.FinalOutputPath)')) == 'false'">$([System.IO.Path]::GetDirectoryName('%(_ReferencedProjectDocumentation.MSBuildSourceProjectFile)'))\%(_ReferencedProjectDocumentation.FinalOutputPath)</FinalFullOutputPath>
 			</_ReferencedProjectDocumentationFullPath>
 			<PackageFile Include="@(_ReferencedProjectDocumentationFullPath -> '%(FinalFullOutputPath)')">
-				<Kind>Doc</Kind>
+				<Kind>Lib</Kind>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
 			</PackageFile>
 		</ItemGroup>
@@ -524,7 +528,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup Condition="'@(_ReferencedProjectDocumentationDependency)' != ''">
 			<PackageFile Include="@(_ReferencedProjectDocumentationDependency -> '%(FullPath)')"
 						 Condition="'%(_ReferencedProjectDocumentationDependency.CopyLocal)' == 'true'">
-				<Kind>Doc</Kind>
+				<Kind>Lib</Kind>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
 			</PackageFile>
 		</ItemGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
@@ -144,14 +144,14 @@ namespace NuGet.Build.Packaging
 			{
 				Filename = "d",
 				Extension = ".dll",
-				Kind = "Lib",
+				Kind = PackageItemKind.Lib,
 				PackagePath = "",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Filename = "d",
 				Extension = ".xml",
-				Kind = "Doc",
+				Kind = PackageItemKind.Lib,
 				PackagePath = "",
 			}));
 		}

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_project_reference.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_project_reference.cs
@@ -26,8 +26,8 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
 			// TODO: build some helpers to make this easier to assert.
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == "Lib"), "Did not include main project output as Library");
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == "Lib"), "Did not include referenced project output as Library");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include main project output as Library");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include referenced project output as Library");
 		}
 
 
@@ -39,8 +39,8 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
 			// TODO: build some helpers to make this easier to assert.
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == "Symbols"), "Did not include main project symbols");
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == "Symbols"), "Did not include referenced project symbols");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include main project symbols");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include referenced project symbols");
 		}
 
 		[Fact]

--- a/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_an_empty_library_project.cs
@@ -95,7 +95,7 @@ namespace NuGet.Build.Packaging
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Extension = ".xml",
-				Kind = "Doc",
+				Kind = PackageItemKind.Lib,
 			}));
 		}
 
@@ -111,7 +111,7 @@ namespace NuGet.Build.Packaging
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
 				Extension = ".xml",
-				Kind = "Doc",
+				Kind = PackageItemKind.Lib,
 			}));
 		}
 

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Rules/general.browseobject.xaml
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Rules/general.browseobject.xaml
@@ -21,5 +21,8 @@
 
     <StringProperty Name="PackageId" DisplayName="Package ID" />
     <StringProperty Name="Title" DisplayName="Title" />
+    <StringProperty Name="ReferenceAssemblyFrameworks" 
+                    DisplayName="Reference Assembly Frameworks" 
+                    Description="Generate a reference assembly for the given target framework by intersecting the APIs of all referenced projects." />
 
 </Rule>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/source.extension.vsixmanifest
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
 		<License>LICENSE.txt</License>
 	</Metadata>
 	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0" />
+		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,)" />
 	</Installation>
 	<Dependencies>
 		<!--<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.6" />-->


### PR DESCRIPTION
These have no mapping in NuGet and only make things more confusing.
Also, make the default primary output package file kind configurable
via the PrimaryOutputPackageFileKind property