### PR TITLE
Fix issue with native projects .vcxproj being built in IDE not seeing…

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -381,7 +381,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
 		
 		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-				 Targets="GetTargetPath"
+				 Targets="GetTargetPathWithTargetPlatformMoniker"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
 				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -63,6 +63,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<IsPackable>$(IsPackable)</IsPackable>
 			<IsNuGetized>$(IsNuGetized)</IsNuGetized>
 		</TargetPathWithTargetPlatformMoniker>
+		<!-- Design Time is annoying and uses a different output item group to return this. Also adust that -->
+		<_MainProjectOutput>
+			<IsPackable>$(IsPackable)</IsPackable>
+			<IsNuGetized>$(IsNuGetized)</IsNuGetized>
+		</_MainProjectOutput>
 	</ItemDefinitionGroup>
 
 	<!--


### PR DESCRIPTION
… that they had the Packaging project installed.

Wasn't sure how to go about unit testing since Design time is involved.

  === TEST EXECUTION SUMMARY ===
     NuGet.Build.Packaging.Tests  Total: 119, Errors: 0, Failed: 8, Skipped: 0, Time: 13.841s

Are failures expected?