### PR TITLE
Use GetTargetPathWithTargetPlatformMoniker and create two stage GetPackageContents

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -200,7 +200,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</GetPackageContentsDependsOn>
 		<GetPackageContentsDependsOn>
 			$(GetPackageContentsDependsOn);
-			GetPackageTargetPath;
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
 			_SplitProjectReferencesByIsPackablePresence;
@@ -276,13 +275,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</PackageFile>
 		</ItemGroup>
 
-		<!-- If packaging the project, provide the metadata as a non-file item -->
-		<ItemGroup Condition="'$(PackageId)' != ''">
-			<PackageFile Include="@(PackageTargetPath->'%(Id)')">
-				<Kind>Metadata</Kind>
-			</PackageFile>
-		</ItemGroup>
-
 		<ItemGroup>
 			<PackageFile>
 				<PackageId>$(PackageId)</PackageId>
@@ -296,7 +288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</AssignPackagePath>
 
 		<MSBuild Projects="@(_IsPackableProject)"
-				 Targets="GetPackageContents"
+				 Targets="GetFinalPackageContents"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_IsPackableProject.SetConfiguration); %(_IsPackableProject.SetPlatform); BuildingPackage=$(BuildingPackage)"
 				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_IsPackableProject)' != ''"
@@ -369,6 +361,35 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</AssignPackagePath>
 	</Target>
 
+	<!-- Separate out the final package file, which is a description of the package itself, into a separate target.
+		 This allows users to craft the description of the package (version, id, etc.) based on the contents if they so choose. 
+	-->
+	<PropertyGroup>
+		<GetFinalPackageContentsDependsOn>
+			$(GetFinalPackageContentsDependsOn);
+			GetPackageContents;
+			GetPackageTargetPath;
+		</GetFinalPackageContentsDependsOn>
+	</PropertyGroup>
+	<Target Name="GetFinalPackageContents" DependsOnTargets="$(GetFinalPackageContentsDependsOn)" Returns="@(_PackageContent)">
+		<!-- If packaging the project, provide the metadata as a non-file item -->
+		<ItemGroup Condition="'$(PackageId)' != ''">
+			<_SelfReferentialPackageFile Include="@(PackageTargetPath->'%(Id)')">
+				<Kind>Metadata</Kind>
+				<PackageId>$(PackageId)</PackageId>
+				<Platform>$(Platform)</Platform>
+				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</_SelfReferentialPackageFile>
+		</ItemGroup>
+
+		<AssignPackagePath Files="@(_SelfReferentialPackageFile)"
+						   Kinds="@(PackageItemKind)"
+						   IsPackaging="$(BuildingPackage)"
+						   Condition="'@(_SelfReferentialPackageFile)' != ''">
+			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
+		</AssignPackagePath>
+	</Target>
+
 	<!-- This target separates project references that have the packaging targets from those that don't -->
 	<Target Name="_SplitProjectReferencesByIsPackablePresence"
 			Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
@@ -376,7 +397,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
 		
 		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-				 Targets="GetTargetPath"
+				 Targets="GetTargetPathWithTargetPlatformMoniker"
 				 BuildInParallel="$(BuildInParallel)"
 				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
 				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -624,7 +645,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<PackDependsOn>
 			$(PackDependsOn)
 			GetPackageTargetPath;
-			GetPackageContents;
+			GetFinalPackageContents;
 			_GenerateReferenceAssemblies;
 		</PackDependsOn>
 	</PropertyGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_complex_pack.cs
@@ -36,7 +36,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_preparing_a_then_contains_assemblies_and_direct_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -72,7 +72,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_preparing_b_then_contains_assemblies_and_direct_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "b", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -108,7 +108,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_preparing_c_then_contains_external_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), new { Configuration = "Release" }, projectName: "c", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -136,7 +136,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_preparing_d_without_package_id_then_does_not_set_package_path()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "d", target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_complex_pack), projectName: "d", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
@@ -26,7 +26,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 			Assert.Contains(result.Logger.Warnings, warning => warning.Code == "NG1001");
@@ -62,7 +62,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -87,7 +87,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -104,7 +104,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -125,7 +125,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -142,7 +142,7 @@ namespace NuGet.Build.Packaging
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
+			}, projectName: "a", target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
@@ -22,7 +22,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_issues_warning_for_missing_nuget()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 			Assert.Contains(result.Logger.Warnings, warning => warning.Code == "NG1001");
@@ -31,7 +31,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_outputs()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -52,7 +52,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_satellite_assembly()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -65,7 +65,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_dependencies()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -82,7 +82,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_dependency_satellite_assembly()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -95,7 +95,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_packagable_project_as_dependency()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -109,7 +109,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_does_not_include_referenced_project_nuget_assembly_reference()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 
@@ -122,7 +122,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_from_packaging_project_then_referenced_outputs_have_original_tfm_path()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project_with_reference_assembly.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project_with_reference_assembly.cs
@@ -22,7 +22,7 @@ namespace NuGet.Build.Packaging
 		[Fact]
 		public void when_getting_contents_then_includes_reference_assembly()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project_with_reference_assembly), target: "GetPackageContents", output: output);
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project_with_reference_assembly), target: "GetFinalPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
 


### PR DESCRIPTION
Description:
Change target used to determine if nugetizer is installed to GetTargetPathWithTargetPlatformMoniker.
This is needed for native projects (.vcxproj) that don't return an item list (so metadata can be attached)
in GetTargetPath. Instead use the target that is expected based on the metadata injection.

Also remove dependency on GetPackageTargetPath from GetPackageContents by creating a second stage,
GetFinalPackageContents. This allows consumers to potienitally adjust package metadata based on the
contents of the package. A simple example of this may be to tag the version of the package with the timestamp
of the most recently modified package member, etc.