### PR TITLE
Fail if project reference is not nugetized

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -203,18 +203,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 			GetPackageTargetPath;
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
-			_SplitProjectReferencesByIsPackablePresence;
+			_SplitProjectReferencesByIsNuGetized;
 			AllProjectOutputGroups;
 			ReadLegacyDependencies;
 		</GetPackageContentsDependsOn>
 		<!-- Only collect referenced projects' outputs if we need to include them -->
 		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
 			$(GetPackageContentsDependsOn)
-			_CollectMissingIsPackableProjectReferencesOutputs;
 			_GetReferenceAssemblyTargetPaths;
 		</GetPackageContentsDependsOn>
 	</PropertyGroup>
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
+		<Error Condition="'@(_NonNuGetizedProjectReference)' != ''"
+			   Code="NG0011"
+			   Text="Some project references cannot be properly packaged. Please install the NuGet.Build.Packaging package on the following projects: @(_NonNuGetizedProjectReference)." />
 
 		<!-- PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
 			 NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
@@ -295,12 +297,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
 
-		<MSBuild Projects="@(_IsPackableProject)"
+		<MSBuild Projects="@(_NuGetizedProjectReference)"
 				 Targets="GetPackageContents"
 				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_IsPackableProject.SetConfiguration); %(_IsPackableProject.SetPlatform); BuildingPackage=$(BuildingPackage)"
-				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_IsPackableProject)' != ''"
-				 RemoveProperties="%(_IsPackableProject.GlobalPropertiesToRemove)">
+				 Properties="%(_NuGetizedProjectReference.SetConfiguration); %(_NuGetizedProjectReference.SetPlatform); BuildingPackage=$(BuildingPackage)"
+				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
+				 RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">
 			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedPackageContent" />
 		</MSBuild>
 
@@ -370,7 +372,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</Target>
 
 	<!-- This target separates project references that have the packaging targets from those that don't -->
-	<Target Name="_SplitProjectReferencesByIsPackablePresence"
+	<Target Name="_SplitProjectReferencesByIsNuGetized"
 			Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
 			Inputs="@(_MSBuildProjectReferenceExistent)"
 			Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
@@ -384,188 +386,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</MSBuild>
 
 		<PropertyGroup>
-			<_HasIsPackable Condition="'%(_ReferencedProjectTargetPath.IsPackable)' != ''">true</_HasIsPackable>
+			<_IsNuGetized Condition="'%(_ReferencedProjectTargetPath.IsNuGetized)' != ''">true</_IsNuGetized>
 		</PropertyGroup>
 
 		<ItemGroup>
-			<_NoIsPackableProject Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_HasIsPackable)' != 'true'" />
-			<_IsPackableProject Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_HasIsPackable)' == 'true'" />
-		</ItemGroup>
-
-	</Target>
-
-	<!-- Includes primary output and dependencies for non-nugetized projects -->
-	<Target Name="_CollectMissingIsPackableProjectReferencesOutputs"
-			Inputs="@(_NoIsPackableProject)"
-			Outputs="%(_NoIsPackableProject.Identity)-BATCH"
-			Condition="'@(_NoIsPackableProject)' != ''">
-		<Warning Text="@(_NoIsPackableProject) does not have the 'NuGet.Build.Packaging' package installed. Only primary output will be packaged."
-				 Code="NG1001" />
-
-		<!-- Get TFM if the project is a packaging project, since we want to use the original project's TFM in that case -->
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="GetTargetFrameworkMoniker"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)"
-				 Condition="'$(IsPackagingProject)' == 'true'">
-			<Output TaskParameter="TargetOutputs" PropertyName="_ReferencedProjectTFM" />
-		</MSBuild>
-
-
-		<!-- Main project and dependencies built output -->
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="BuiltProjectOutputGroup"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectBuiltOutput" />
-		</MSBuild>
-
-		<ItemGroup>
-			<PackageFile Include="@(_ReferencedProjectBuiltOutput -> '%(FinalOutputPath)')">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="BuiltProjectOutputGroupDependencies"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectOutputDependency" />
-		</MSBuild>
-
-		<ItemGroup>
-			<!-- NOTE: this default heuristics does not include assemblies referenced from nuget v3 packages which look like the following:
-					BuiltProjectOutputGroupDependency: %UserProfile%\.nuget\packages\Newtonsoft.Json\6.0.4\lib\net45\Newtonsoft.Json.dll
-						CopyLocal=false
-						NuGetIsFrameworkReference=false
-						NuGetPackageId=Newtonsoft.Json
-						NuGetPackageVersion=6.0.4
-						NuGetSourceType=Package
-						ResolvedFrom={RawFileName}
-						
-				Since the dependencies include the actual closure of all transitive nuget package dependencies (from its 
-				lock.json or packages.config), we can't rely on these to provide the top-level dependencies we actually 
-				need either.
-			-->
-			<PackageFile Include="@(_ReferencedProjectOutputDependency -> '%(FullPath)')"
-						 Condition="'%(_ReferencedProjectOutputDependency.CopyLocal)' == 'true' and
-						            '%(_ReferencedProjectOutputDependency.FrameworkFile)' != 'true' and 
-									'%(_ReferencedProjectOutputDependency.ResolvedFrom)' != '{TargetFrameworkDirectory}'">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<!-- Main project and dependencies symbols -->
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Condition="'$(IncludeSymbolsInPackage)' == 'true'"
-				 Targets="DebugSymbolsProjectOutputGroup"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectDebugSymbols" />
-		</MSBuild>
-
-		<ItemGroup>
-			<PackageFile Include="@(_ReferencedProjectDebugSymbols -> '%(FinalOutputPath)')">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Condition="'$(IncludeSymbolsInPackage)' == 'true'"
-				 Targets="DebugSymbolsProjectOutputGroupDependencies"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectOutputDependencySymbols" />
-		</MSBuild>
-
-		<ItemGroup>
-			<PackageFile Include="@(_ReferencedProjectOutputDependencySymbols -> '%(FullPath)')"
-						 Condition="'%(_ReferencedProjectOutputDependencySymbols.CopyLocal)' == 'true'">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<!-- Main project and dependencies documentation -->
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="DocumentationProjectOutputGroup"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectDocumentation" />
-		</MSBuild>
-
-		<ItemGroup Condition="'@(_ReferencedProjectDocumentation)' != ''">
-			<!-- Ensure FinalOutputPath is a full path. Remove when https://github.com/Microsoft/msbuild/pull/1076 ships -->
-			<_ReferencedProjectDocumentationFullPath Include="@(_ReferencedProjectDocumentation)" Condition="$([System.IO.Path]::IsPathRooted('%(_ReferencedProjectDocumentation.FinalOutputPath)')) == 'true'">
-				<FinalFullOutputPath>%(_ReferencedProjectDocumentation.FinalOutputPath)</FinalFullOutputPath>
-			</_ReferencedProjectDocumentationFullPath>
-			<_ReferencedProjectDocumentationFullPath Include="@(_ReferencedProjectDocumentation)" Condition="$([System.IO.Path]::IsPathRooted('%(_ReferencedProjectDocumentation.FinalOutputPath)')) == 'false'">
-				<FinalFullOutputPath Condition="$([System.IO.Path]::IsPathRooted('%(_ReferencedProjectDocumentation.FinalOutputPath)')) == 'false'">$([System.IO.Path]::GetDirectoryName('%(_ReferencedProjectDocumentation.MSBuildSourceProjectFile)'))\%(_ReferencedProjectDocumentation.FinalOutputPath)</FinalFullOutputPath>
-			</_ReferencedProjectDocumentationFullPath>
-			<PackageFile Include="@(_ReferencedProjectDocumentationFullPath -> '%(FinalFullOutputPath)')">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="DocumentationProjectOutputGroupDependencies"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectDocumentationDependency" />
-		</MSBuild>
-
-		<ItemGroup Condition="'@(_ReferencedProjectDocumentationDependency)' != ''">
-			<PackageFile Include="@(_ReferencedProjectDocumentationDependency -> '%(FullPath)')"
-						 Condition="'%(_ReferencedProjectDocumentationDependency.CopyLocal)' == 'true'">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<!-- Main project and dependencies satellite assemblies -->
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="SatelliteDllsProjectOutputGroup"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectSatelliteDll" />
-		</MSBuild>
-
-		<ItemGroup Condition="'@(_ReferencedProjectSatelliteDll)' != ''">
-			<!-- Change to %(FinalOutputPath) when https://github.com/Microsoft/msbuild/pull/1115 ships -->
-			<PackageFile Include="@(_ReferencedProjectSatelliteDll -> '%(FullPath)')">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-			</PackageFile>
-		</ItemGroup>
-
-		<MSBuild Projects="@(_NoIsPackableProject)"
-				 Targets="SatelliteDllsProjectOutputGroupDependencies"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NoIsPackableProject.SetConfiguration); %(_NoIsPackableProject.SetPlatform)"
-				 RemoveProperties="%(_NoIsPackableProject.GlobalPropertiesToRemove)">
-			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectDependencySatelliteDll" />
-		</MSBuild>
-
-		<ItemGroup Condition="'@(_ReferencedProjectDependencySatelliteDll)' != ''">
-			<!-- Change to %(FinalOutputPath) when https://github.com/Microsoft/msbuild/pull/1115 ships -->
-			<PackageFile Include="@(_ReferencedProjectDependencySatelliteDll -> '%(FullPath)')"
-						 Condition="'%(_ReferencedProjectDependencySatelliteDll.CopyLocal)' == 'true'">
-				<Kind>Lib</Kind>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' == 'true'">$(_ReferencedProjectTFM)</TargetFrameworkMoniker>
-				<TargetPath Condition="'%(_ReferencedProjectDependencySatelliteDll.DestinationSubDirectory)' != ''">%(_ReferencedProjectDependencySatelliteDll.DestinationSubDirectory)%(_ReferencedProjectDependencySatelliteDll.Filename)%(_ReferencedProjectDependencySatelliteDll.Extension)</TargetPath>
-			</PackageFile>
+			<!-- We will fail for this first group: project references that aren't excluded from packaging, yet haven't been nugetized -->
+			<_NonNuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)" 
+										   Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' != 'true'" />
+			<!-- We will only process for packaging the project references that haven't been excluded from packaging and are nugetized -->
+			<_NuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)" 
+										Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' == 'true'" />
 		</ItemGroup>
 
 	</Target>

--- a/src/Build/NuGet.Build.Packaging.Tasks/Properties/Resources.Designer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Properties/Resources.Designer.cs
@@ -68,5 +68,14 @@ namespace NuGet.Build.Packaging.Properties {
                 return ResourceManager.GetString("ErrorCode_NG0010", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project references to include in package must be nugetized..
+        /// </summary>
+        public static string ErrorCode_NG0011 {
+            get {
+                return ResourceManager.GetString("ErrorCode_NG0011", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Build/NuGet.Build.Packaging.Tasks/Properties/Resources.resx
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Properties/Resources.resx
@@ -120,4 +120,7 @@
   <data name="ErrorCode_NG0010" xml:space="preserve">
     <value>Package file '{0}' must have either 'Kind' or 'PackagePath' metadata.</value>
   </data>
+  <data name="ErrorCode_NG0011" xml:space="preserve">
+    <value>Project references to include in package must be nugetized.</value>
+  </data>
 </root>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project/b/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project/b/b.csproj
@@ -15,5 +15,5 @@
 			<Name>d</Name>
 		</ProjectReference>
 	</ItemGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/b.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project_with_reference_assembly/b/b.csproj
@@ -9,5 +9,5 @@
 	<ItemGroup>
 		<Compile Include="MyClass.cs" />
 	</ItemGroup>
-	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_non_nugetized_reference.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Microsoft.Build.Execution;
@@ -20,7 +21,7 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
-		public void when_getting_contents_then_issues_warning_for_missing_nuget()
+		public void when_getting_contents_then_fails()
 		{
 			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
 			{
@@ -28,128 +29,21 @@ namespace NuGet.Build.Packaging
 				IncludeFrameworkReferences = "false",
 			}, projectName: "a", target: "GetPackageContents", output: output);
 
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-			Assert.Contains(result.Logger.Warnings, warning => warning.Code == "NG1001");
+			Assert.Equal(TargetResultCode.Failure, result.ResultCode);
+			Assert.Contains(result.Logger.Errors, error => error.Code == "NG0011");
 		}
 
 		[Fact]
-		public void when_include_in_package_false_then_does_not_include_referenced_project_outputs()
+		public void when_include_in_package_false_then_does_not_fail()
 		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_project_reference),
-				properties: new { IncludeInPackage = "false" },
-				output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.DoesNotContain(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.dll",
-			}));
-			Assert.DoesNotContain(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.xml",
-			}));
-			Assert.DoesNotContain(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.dll",
-			}));
-		}
-
-		[Fact]
-		public void when_getting_contents_then_includes_referenced_project_outputs()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
+			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), properties: new
 			{
 				Configuration = "Release",
 				IncludeFrameworkReferences = "false",
+				IncludeInPackage = "false"
 			}, projectName: "a", target: "GetPackageContents", output: output);
 
 			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.dll",
-			}));
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.xml",
-			}));
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\b.dll",
-			}));
-		}
-
-		[Fact]
-		public void when_getting_contents_then_includes_referenced_project_satellite_assembly()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
-			{
-				Configuration = "Release",
-				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\es-AR\b.resources.dll",
-			}));
-		}
-
-		[Fact]
-		public void when_getting_contents_then_includes_referenced_project_dependencies()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
-			{
-				Configuration = "Release",
-				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\d.dll",
-			}));
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\d.dll",
-			}));
-		}
-
-		[Fact]
-		public void when_getting_contents_then_includes_referenced_project__dependency_satellite_assembly()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
-			{
-				Configuration = "Release",
-				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.Contains(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\es-AR\d.resources.dll",
-			}));
-		}
-
-		[Fact]
-		public void when_getting_contents_then_does_not_include_referenced_project_nuget_assembly_reference()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_library_with_non_nugetized_reference), new
-			{
-				Configuration = "Release",
-				IncludeFrameworkReferences = "false",
-			}, projectName: "a", target: "GetPackageContents", output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-
-			Assert.DoesNotContain(result.Items, item => item.Matches(new
-			{
-				PackagePath = @"lib\net46\Newtonsoft.Json.dll",
-			}));
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
@@ -18,16 +18,7 @@ namespace NuGet.Build.Packaging
 		{
 			this.output = output;
 		}
-
-		[Fact]
-		public void when_getting_contents_then_issues_warning_for_missing_nuget()
-		{
-			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
-
-			Assert.Equal(TargetResultCode.Success, result.ResultCode);
-			Assert.Contains(result.Logger.Warnings, warning => warning.Code == "NG1001");
-		}
-
+        
 		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_outputs()
 		{


### PR DESCRIPTION
Non-excluded project references (IncludeInPackage=false) fail if
they haven't been nugetized.

The previous behavior of trying to automagically include as much
as possible from the project reference by default resulted in an
additional complicated target and confusing behavior for users
when only some references are nugetized.

Besides, under VS2017+ it's trivial to automatically nugetize
all libraries even from a VSIX installation, so this would have
been legacy code the moment we shipped.

Fixes https://github.com/NuGet/Home/issues/3983