### PR TITLE
Bump Clide to get updated Merq indirect dependency

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -4,7 +4,8 @@
 		<clear />
     <add key="NuGetCI" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
 		<add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-		<add key="mobessen" value="https://ci.appveyor.com/nuget/merq" />
+		<add key="Merq-CI" value="https://ci.appveyor.com/nuget/merq" />
+		<add key="Clide-CI" value="https://ci.appveyor.com/nuget/clide" />
 	</packageSources>
 	<disabledPackageSources>
 		<clear />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.14/NuGet.Packaging.VisualStudio.14.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.14/NuGet.Packaging.VisualStudio.14.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
-    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Shared.props))\NuGet.Build.Packaging.Shared.props" />
@@ -14,6 +13,8 @@
     <AssemblyName>NuGet.Packaging.VisualStudio.14</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetVsixContainerName>NuGetizer3000-VS2015.vsix</TargetVsixContainerName>
+    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
+	<DeployExtension Condition="'$(DeployExtension)' == '' And '$(Configuration)' == 'Release'">false</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.14/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.14/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Clarius.VisualStudio": "1.3.7",
-    "Clide.Installer": "3.0.103-pre",
+    "Clide.Installer": "3.0.105-pre",
     "GitInfo": "1.1.32",
     "Merq": "1.0.1-alpha",
     "Microsoft.VisualStudio.ProjectSystem.SDK": "14.1.127-pre",
@@ -9,6 +9,7 @@
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
     "Microsoft.VSSDK.BuildTools": "14.3.25420",
     "MSBuilder.ThisAssembly.Project": "0.3.1",
+    "MSBuilder.VsixDependency": "0.2.2",
     "VSSDK.ComponentModelHost.11": "11.0.4"
   },
   "frameworks": {

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
-    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Shared.props))\NuGet.Build.Packaging.Shared.props" />
@@ -14,6 +13,8 @@
     <AssemblyName>NuGet.Packaging.VisualStudio.15</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetVsixContainerName>NuGetizer3000-VS2017.vsix</TargetVsixContainerName>
+    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
+	<DeployExtension Condition="'$(DeployExtension)' == '' And '$(Configuration)' == 'Release'">false</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Clarius.VisualStudio": "1.3.7",
-    "Clide.Installer": "3.0.103-pre",
+    "Clide.Installer": "3.0.105-pre",
     "GitInfo": "1.1.32",
     "Merq": "1.0.1-alpha",
     "Microsoft.VisualStudio.ProjectSystem.SDK": "15.0.594-pre",
@@ -11,7 +11,7 @@
     "MSBuilder.DumpItems": "0.2.1",
     "MSBuilder.Introspect": "0.1.5",
     "MSBuilder.ThisAssembly.Project": "0.3.1",
-    "MSBuilder.VsixDependency": "0.2.1",
+    "MSBuilder.VsixDependency": "0.2.2",
     "MSBuilder.VsixInstaller": "0.2.9",
     "VSSDK.ComponentModelHost.11": "11.0.4"
   },

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Clide": "3.0.103-pre",
+    "Clide": "3.0.105-pre",
     "GitInfo": "1.1.32",
     "Merq": "1.0.1-alpha",
     "Microsoft.VisualStudio.Shell.14.0": "14.3.25407",


### PR DESCRIPTION
Also don't deploy the extension when building Release builds by default.
This allows building the solution from either VS2015 or VS2017 in Release
mode, since the VSSDK targets that fail won't run (the ones that deploy
and depend on the current VS being the same being deployed to).

Also, register the dependent CI feeds, which update faster than nuget.org