### PR TITLE
Don't append -dev label, to allow floating version dep.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -136,7 +136,6 @@
 		<!-- For now this is an informative version #, used to update CI -->
 		<PropertyGroup>
 			<GitSemVerDashLabel>%(GitInfo.GitSemVerDashLabel)</GitSemVerDashLabel>
-			<GitSemVerDashLabel Condition="'%(GitInfo.GitBranch)' == 'dev'">-dev</GitSemVerDashLabel>
 			<GitSemVerDashLabel Condition="'%(GitInfo.GitBranch)' == 'undefined'">-pr</GitSemVerDashLabel>
 			<GitSemVerDashLabel Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">-pr$(APPVEYOR_PULL_REQUEST_NUMBER)</GitSemVerDashLabel>
 			<Version>%(GitInfo.GitSemVerMajor).%(GitInfo.GitSemVerMinor).%(GitInfo.GitSemVerPatch)$(GitSemVerDashLabel)</Version>


### PR DESCRIPTION
At the moment, NuGet does not support a floating version that includes a
pre-release label, like 0.1.*-dev, so by appending the label, we're making
it impossible for CI-depending consumers to always opt for the latest
version automatically.

See https://docs.nuget.org/ndocs/consume-packages/dependency-resolution#floating-versions