### PR TITLE
Avoid SxS issues with NuGet tasks by IL merging

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -5,14 +5,13 @@
 	<PropertyGroup Condition="'$(IsCIBuild)' != 'true'">
 		<!-- Local build defaults -->
 		<Configuration Condition=" '$(Configuration)' == ''">Debug</Configuration>
-		<RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(IsCIBuild)' == 'true'">
 		<Configuration Condition=" '$(Configuration)' == ''">Release</Configuration>
-		<RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">true</RunCodeAnalysis>
 	</PropertyGroup>
 	
 	<PropertyGroup>
+		<RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == ''">false</RunCodeAnalysis>
 		<IntermediateOutputPath>.nuget\</IntermediateOutputPath>
 		<PackagesPath>$(IntermediateOutputPath)packages</PackagesPath>
 		<CommonBuildProperties>WarningLevel=0;NoWarn=1591;Out=$(Out);Configuration=$(Configuration);RunCodeAnalysis=$(RunCodeAnalysis)</CommonBuildProperties>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
@@ -26,7 +26,7 @@
 	<Import Project="$(OutputPath)NuGet.Build.Packaging.targets" 
 			Condition="'$(PackOnBuild)' == 'true' and Exists('$(OutputPath)NuGet.Build.Packaging.targets')" />
 
-	<Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
+	<Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents" Returns="@(PackageFile)">
 		<!-- Update packaging version targets -->
 		<PropertyGroup>
 			<XmlNs>&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;</XmlNs>
@@ -67,12 +67,6 @@
 				<PackagePath>build\%(Filename)%(Extension)</PackagePath>
 			</PackageFile>
 			<PackageFile Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-				<PackagePath>build\%(Filename)%(Extension)</PackagePath>
-			</PackageFile>
-			<PackageFile Include="@(ReferencePath)" Condition="$([System.String]::new('%(Filename)').StartsWith('NuGet'))">
-				<PackagePath>build\%(Filename)%(Extension)</PackagePath>
-			</PackageFile>
-			<PackageFile Include="@(ReferencePath)" Condition="$([System.String]::new('%(Filename)').StartsWith('Newtonsoft.Json'))">
 				<PackagePath>build\%(Filename)%(Extension)</PackagePath>
 			</PackageFile>
 		</ItemGroup>
@@ -140,5 +134,45 @@ namespace $(RootNamespace)
 			</Reference>
 		</ItemGroup>
 	</Target>
-	
+
+	<PropertyGroup>
+		<ILMerge>$(NuGetPackageRoot)ILRepack\2.0.12\tools\ILRepack.exe</ILMerge>
+	</PropertyGroup>
+
+	<Target Name="ILMerge"
+			AfterTargets="CoreCompile"
+			DependsOnTargets="CoreCompile"
+			Inputs="@(IntermediateAssembly)"
+			Outputs="$(TargetPath)"
+			Returns="@(MergedAssemblies)"
+			Condition="'$(Configuration)' == 'Release' And '$(ILMerge)' != 'false'">
+		<GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+			<Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
+		</GetReferenceAssemblyPaths>
+		<ItemGroup>
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Newtonsoft'))" />
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('NuGet'))" />
+			<!--<UnmergedAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(MergedAssemblies)" />
+			<UnmergedAssembliesDir Include="@(UnmergedAssemblies -> '%(RootDir)%(Directory)')" />-->
+			<ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+			<ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
+			<LibDir Include="@(ReferenceCopyLocalDirs->Distinct())" />
+		</ItemGroup>
+		<PropertyGroup>
+			<ILMergeArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:&quot;$(AssemblyOriginatorKeyFile)&quot;</ILMergeArgs>
+		</PropertyGroup>
+		<Exec Command="&quot;$(ILMerge)&quot; @(LibDir->'/lib:&quot;%(Identity).&quot;', ' ') $(ILMergeArgs) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
+			  WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)"
+			  StandardErrorImportance="high"
+			  StandardOutputImportance="low"
+			  ConsoleToMSBuild="true"
+			  ContinueOnError="true">
+			<Output TaskParameter="ConsoleOutput" PropertyName="ILMergeOutput"/>
+			<Output TaskParameter="ExitCode" PropertyName="ExitCode"/>
+		</Exec>
+		<Message Importance="high" Text="$(ILMergeOutput)" Condition="'$(ExitCode)' != '0'" />
+		<Error Text="$(ILMergeOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+		<Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+	</Target>
+
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/project.json
+++ b/src/Build/NuGet.Build.Packaging.Tasks/project.json
@@ -1,12 +1,13 @@
 ﻿{
   "dependencies": {
     "GitInfo": "1.1.32",
+    "ILRepack": "2.0.12",
     "MSBuilder.ThisAssembly.Project": "0.3.1",
     "netfx-System.StringResources": "3.0.14",
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.Client": "3.5.0-rtm-1938",
-    "NuGet.Packaging": "3.5.0-rtm-1938",
-    "NuGet.ProjectManagement": "3.5.0-rtm-1938"
+    "NuGet.Client": "3.5.0",
+    "NuGet.Packaging": "3.5.0",
+    "NuGet.ProjectManagement": "3.5.0"
   },
   "frameworks": {
     "net46": {}

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.targets
@@ -5,13 +5,17 @@
 		<!-- Prevents Fody.VerifyTask from running -->
 		<NCrunch>1</NCrunch>
 	</PropertyGroup>
+
+	<Target Name="RemoveMergedAssemblies" Condition="'$(Configuration)' == 'Release'" AfterTargets="ResolveNuGetPackageAssets">
+		<ItemGroup>
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Newtonsoft'))" />
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('NuGet'))" />
+			<Reference Remove="@(MergedAssemblies)" />
+		</ItemGroup>
+	</Target>
 	
 	<Target Name="AddMSBuildReferences" BeforeTargets="ResolveAssemblyReferences">
 		<ItemGroup>
-			<!-- TODO: to replace with the MSBuild nugets once they are more generally available -->
-			<!--<Reference Include="Microsoft.Build.Engine">
-				<HintPath>$(MSBuildBinPath)\Microsoft.Build.Engine.dll</HintPath>
-			</Reference>-->
 			<Reference Include="Microsoft.Build">
 				<HintPath>$(MSBuildBinPath)\Microsoft.Build.dll</HintPath>
 			</Reference>


### PR DESCRIPTION
During a build, it's possible that a different version of the NuGet
assemblies are loaded by the MSBuild process (i.e. from the MSBuild
extensions path), potentially causing this package to break.

So instead of including the NuGet (and Newtonsoft.Json) assemblies
as external references, we merge them with the main tasks assemblies,
thereby isolating our tasks from those deps and ensuring that the
targets will behave as tested and shipped regardless of the installed
version of NuGet.