### PR TITLE
Support simplified authoring projects

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -202,15 +202,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<GetPackageContentsDependsOn>
 			$(GetPackageContentsDependsOn);
 			GetPackageTargetPath;
+			ReadLegacyDependencies;
+		</GetPackageContentsDependsOn>
+		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
+			$(GetPackageContentsDependsOn)
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
 			_SplitProjectReferencesByIsNuGetized;
 			AllProjectOutputGroups;
-			ReadLegacyDependencies;
-		</GetPackageContentsDependsOn>
-		<!-- Only collect referenced projects' outputs if we need to include them -->
-		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
-			$(GetPackageContentsDependsOn)
 			_GetReferenceAssemblyTargetPaths;
 		</GetPackageContentsDependsOn>
 	</PropertyGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <None Include="project.json" />
     <None Include="NuGet.Build.Packaging.Tests.targets" />
+    <Content Include="Scenarios\given_a_custom_build_project\Readme.txt" />
     <Content Include="Scenarios\given_a_library_with_content\content-with-include-true.txt" />
     <Content Include="Scenarios\given_a_library_with_content\content-with-include-false.txt" />
     <Content Include="Scenarios\given_a_library_with_content\none-with-include-false.txt" />
@@ -28,9 +29,8 @@
     <Content Include="Scenarios\given_a_library_with_content\Resources\drawable-xhdpi\Icon.png" />
     <Content Include="Scenarios\given_a_library_with_content\Resources\drawable-xxhdpi\Icon.png" />
     <Content Include="Scenarios\given_a_library_with_content\Resources\drawable-xxxhdpi\Icon.png" />
-    <None Include="Scenarios\given_a_packaging_project\a.nuproj">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="Scenarios\given_a_custom_build_project\build.proj" />
+    <None Include="Scenarios\given_a_packaging_project\a.nuproj" />
     <Content Include="Scenarios\given_a_packaging_project\b.sln" />
     <Content Include="Scenarios\given_a_packaging_project\b\b.csproj" />
     <Content Include="Scenarios\given_a_packaging_project\c.csproj" />
@@ -50,9 +50,7 @@
     <Content Include="Scenarios\given_a_complex_pack\c.csproj" />
     <Content Include="Scenarios\given_a_complex_pack\d.csproj" />
     <Content Include="Scenarios\given_a_complex_pack\e.csproj" />
-    <Content Include="Scenarios\given_a_library_with_non_nugetized_reference\a.csproj">
-      <SubType>Designer</SubType>
-    </Content>
+    <Content Include="Scenarios\given_a_library_with_non_nugetized_reference\a.csproj" />
     <Content Include="Scenarios\given_a_multi_platform_solution\android\forms.android.csproj" />
     <Content Include="Scenarios\given_a_multi_platform_solution\common\common.csproj" />
     <Content Include="Scenarios\given_a_multi_platform_solution\forms.sln" />
@@ -90,6 +88,7 @@
       <DependentUpon>Builder.cs</DependentUpon>
     </Compile>
     <Compile Include="GetApiIntersectTargetPathsTests.cs" />
+    <Compile Include="given_a_custom_build_project.cs" />
     <Compile Include="given_a_packaging_project.cs" />
     <Compile Include="given_a_multi_platform_solution.cs" />
     <Compile Include="given_a_library_with_content.cs" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_custom_build_project/build.proj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_custom_build_project/build.proj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<!-- This will be the right path when we run from xunit in the bin/$(Configuration) folder -->
+		<NuGetTargetsPath Condition="'$(NuGetTargetsPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.props))</NuGetTargetsPath>
+		<!-- This will be the right path when we run from MSBuild from the source location inside the tests project -->
+		<NuGetTargetsPath Condition="!Exists('$(NuGetTargetsPath)\NuGet.Build.Packaging.props')">$(MSBuildThisFileDirectory)..\..\..\NuGet.Build.Packaging.Tasks\bin\Debug</NuGetTargetsPath>
+	</PropertyGroup>
+	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.props" />
+
+	<PropertyGroup>
+		<PackageId>build</PackageId>
+		<PackageVersion>1.0.0</PackageVersion>
+		<Authors>NuGet</Authors>
+		<Description>Package for '$(MSBuildProjectName)' project.</Description>
+		<IncludeOutputsInPackage>false</IncludeOutputsInPackage>
+		<IncludeFrameworkReferencesInPackage>true</IncludeFrameworkReferencesInPackage>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageFile Include="Readme.txt" />
+	</ItemGroup>
+	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.targets" />
+</Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_custom_build_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_custom_build_project.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Microsoft.Build.Execution;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Build.Packaging
+{
+	public class given_a_custom_build_project
+	{
+		ITestOutputHelper output;
+
+		public given_a_custom_build_project(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public void when_packing_then_can_include_content()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_custom_build_project));
+
+			Assert.Equal(TargetResultCode.Success, result.ResultCode);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				PackagePath = "Readme.txt",
+			}));
+		}
+	}
+}


### PR DESCRIPTION
By moving some target dependencies under the condition that IncludeOutputsInPackage
is true, we allow simple .proj files without the MS.Common targets to also participate
in nuget packing with minimal configuration, namely setting IncludeOutputsInPackage=false
and IncludeFrameworkReferencesInPackage=true.