### PR TITLE
Using the Profile 111 when unfolding the PCL project

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.14/Templates/Projects/PortableClassLibrary/PortableClassLibrary.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.14/Templates/Projects/PortableClassLibrary/PortableClassLibrary.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>$safeprojectname$</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.14/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.14/project.json
@@ -3,7 +3,7 @@
     "Clarius.VisualStudio": "1.3.7",
     "Clide.Installer": "3.0.105-pre",
     "GitInfo": "1.1.32",
-    "Merq": "1.0.1-alpha",
+    "Merq": "1.1.3-alpha",
     "Microsoft.VisualStudio.ProjectSystem.SDK": "14.1.127-pre",
     "Microsoft.VisualStudio.Shell.14.0": "14.3.25407",
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/Templates/Projects/PortableClassLibrary/PortableClassLibrary.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/Templates/Projects/PortableClassLibrary/PortableClassLibrary.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>$safeprojectname$</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
@@ -3,7 +3,7 @@
     "Clarius.VisualStudio": "1.3.7",
     "Clide.Installer": "3.0.105-pre",
     "GitInfo": "1.1.32",
-    "Merq": "1.0.1-alpha",
+    "Merq": "1.1.3-alpha",
     "Microsoft.VisualStudio.ProjectSystem.SDK": "15.0.594-pre",
     "Microsoft.VisualStudio.Shell.14.0": "14.3.25407",
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Clide": "3.0.105-pre",
     "GitInfo": "1.1.32",
-    "Merq": "1.0.1-alpha",
+    "Merq": "1.1.3-alpha",
     "Microsoft.VisualStudio.Shell.14.0": "14.3.25407",
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
     "MSBuilder.ThisAssembly.Project": "0.3.1",


### PR DESCRIPTION
Fixes bug#51274 - [NuGetizer] Multiplatform library uses PCL Profile 151 instead of Profile 111