### PR TITLE
Support all ApiIntersect parameters api

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -17,6 +17,8 @@ namespace NuGet.Build.Packaging.Tasks
 
 		public ITaskItem[] ReferencePath { get; set; }
 
+		public ITaskItem[] ExcludeType { get; set; }
+
 		[Required]
 		public ITaskItem RootOutputDirectory { get; set; }
 
@@ -62,6 +64,14 @@ namespace NuGet.Build.Packaging.Tasks
 			{
 				builder.AppendSwitch("-r");
 				builder.AppendFileNameIfNotNull(referencePath.ItemSpec);
+			}
+
+			foreach (var excludeType in ExcludeType.NullAsEmpty())
+			{
+				builder.AppendSwitch("-b");
+				builder.AppendTextUnquoted(" \"");
+				builder.AppendTextUnquoted(excludeType.ItemSpec);
+				builder.AppendTextUnquoted("\"");
 			}
 
 			return builder.ToString();

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -21,6 +21,8 @@ namespace NuGet.Build.Packaging.Tasks
 
 		public ITaskItem[] RemoveAbstractTypeMembers { get; set; }
 
+		public ITaskItem[] ExcludeAssembly { get; set; }
+
 		public string KeepInternalConstructors { get; set; }
 
 		public string KeepMarshalling { get; set; }
@@ -86,6 +88,12 @@ namespace NuGet.Build.Packaging.Tasks
 				builder.AppendTextUnquoted(" \"");
 				builder.AppendTextUnquoted(removeAbstractType.ItemSpec);
 				builder.AppendTextUnquoted("\"");
+			}
+
+			foreach (var assembly in ExcludeAssembly.NullAsEmpty())
+			{
+				builder.AppendSwitch("-e");
+				builder.AppendFileNameIfNotNull(assembly.ItemSpec);
 			}
 
 			AppendSwitchIfTrue(builder, "-k", KeepInternalConstructors);

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -19,6 +19,10 @@ namespace NuGet.Build.Packaging.Tasks
 
 		public ITaskItem[] ExcludeType { get; set; }
 
+		public string KeepInternalConstructors { get; set; }
+
+		public string KeepMarshalling { get; set; }
+
 		[Required]
 		public ITaskItem RootOutputDirectory { get; set; }
 
@@ -74,6 +78,10 @@ namespace NuGet.Build.Packaging.Tasks
 				builder.AppendTextUnquoted("\"");
 			}
 
+			AppendSwitchIfTrue(builder, "-k", KeepInternalConstructors);
+
+			AppendSwitchIfTrue(builder, "-m", KeepMarshalling);
+
 			return builder.ToString();
 		}
 
@@ -119,6 +127,16 @@ namespace NuGet.Build.Packaging.Tasks
 			return Path.Combine(
 				Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify),
 				@"Reference Assemblies\Microsoft\Framework\.NETPortable");
+		}
+
+		static void AppendSwitchIfTrue(CommandLineBuilder builder, string switchName, string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return;
+
+			bool result;
+			if (bool.TryParse(value, out result))
+				builder.AppendSwitch(switchName);
 		}
 	}
 }

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -19,6 +19,8 @@ namespace NuGet.Build.Packaging.Tasks
 
 		public ITaskItem[] ExcludeType { get; set; }
 
+		public ITaskItem[] RemoveAbstractTypeMembers { get; set; }
+
 		public string KeepInternalConstructors { get; set; }
 
 		public string KeepMarshalling { get; set; }
@@ -75,6 +77,14 @@ namespace NuGet.Build.Packaging.Tasks
 				builder.AppendSwitch("-b");
 				builder.AppendTextUnquoted(" \"");
 				builder.AppendTextUnquoted(excludeType.ItemSpec);
+				builder.AppendTextUnquoted("\"");
+			}
+
+			foreach (var removeAbstractType in RemoveAbstractTypeMembers.NullAsEmpty())
+			{
+				builder.AppendSwitch("-a");
+				builder.AppendTextUnquoted(" \"");
+				builder.AppendTextUnquoted(removeAbstractType.ItemSpec);
 				builder.AppendTextUnquoted("\"");
 			}
 

--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -15,6 +15,8 @@ namespace NuGet.Build.Packaging.Tasks
 		[Required]
 		public ITaskItem[] IntersectionAssembly { get; set; }
 
+		public ITaskItem[] ReferencePath { get; set; }
+
 		[Required]
 		public ITaskItem RootOutputDirectory { get; set; }
 
@@ -54,6 +56,12 @@ namespace NuGet.Build.Packaging.Tasks
 			{
 				builder.AppendSwitch("-i");
 				builder.AppendFileNameIfNotNull(assembly.ItemSpec);
+			}
+
+			foreach (var referencePath in ReferencePath.NullAsEmpty())
+			{
+				builder.AppendSwitch("-r");
+				builder.AppendFileNameIfNotNull(referencePath.ItemSpec);
 			}
 
 			return builder.ToString();

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -517,11 +517,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 		Inputs="@(IntersectionAssembly)"
 		Outputs="@(_ReferenceAssemblyTargetPath)">
 
+		<PropertyGroup>
+			<EnableDefaultIntersectionAssemblyReferencePath Condition="'$(EnableDefaultIntersectionAssemblyReferencePath)' == ''">true</EnableDefaultIntersectionAssemblyReferencePath>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<_IntersectionReferencePath Include="@(IntersectionAssembly->'%(RootDir)%(Directory)')" Condition="'$(EnableDefaultIntersectionAssemblyReferencePath)' == 'true'" />
+			<_IntersectionReferencePath Include="$(IntersectionAssemblyReferencePath)" />
+		</ItemGroup>
+		
 		<ApiIntersect
 			Framework="%(ReferenceAssemblyFramework.Identity)"
 			RootOutputDirectory="$(IntermediateOutputPath)"
 			IntersectionAssembly="@(IntersectionAssembly)"
-			ReferencePath="$(IntersectionAssemblyReferencePath)"
+			ReferencePath="@(_IntersectionReferencePath)"
 			ExcludeType="$(IntersectionExcludeType)"
 			RemoveAbstractTypeMembers="$(IntersectionRemoveAbstractTypeMembers)"
 			ExcludeAssembly="@(IntersectionExcludeAssembly)"

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -522,6 +522,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			RootOutputDirectory="$(IntermediateOutputPath)"
 			IntersectionAssembly="@(IntersectionAssembly)"
 			ReferencePath="$(IntersectionAssemblyReferencePath)"
+			ExcludeType="$(IntersectionExcludeType)"
 			ToolPath="$(ApiIntersectToolPath)"
 			ToolExe="$(ApiIntersectToolExe)">
 			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -524,6 +524,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			ReferencePath="$(IntersectionAssemblyReferencePath)"
 			ExcludeType="$(IntersectionExcludeType)"
 			RemoveAbstractTypeMembers="$(IntersectionRemoveAbstractTypeMembers)"
+			ExcludeAssembly="@(IntersectionExcludeAssembly)"
 			KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
 			KeepMarshalling="$(IntersectionKeepMarshalling)"
 			ToolPath="$(ApiIntersectToolPath)"

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -523,6 +523,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 			IntersectionAssembly="@(IntersectionAssembly)"
 			ReferencePath="$(IntersectionAssemblyReferencePath)"
 			ExcludeType="$(IntersectionExcludeType)"
+			KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
+			KeepMarshalling="$(IntersectionKeepMarshalling)"
 			ToolPath="$(ApiIntersectToolPath)"
 			ToolExe="$(ApiIntersectToolExe)">
 			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -521,6 +521,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			Framework="%(ReferenceAssemblyFramework.Identity)"
 			RootOutputDirectory="$(IntermediateOutputPath)"
 			IntersectionAssembly="@(IntersectionAssembly)"
+			ReferencePath="$(IntersectionAssemblyReferencePath)"
 			ToolPath="$(ApiIntersectToolPath)"
 			ToolExe="$(ApiIntersectToolExe)">
 			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -523,6 +523,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 			IntersectionAssembly="@(IntersectionAssembly)"
 			ReferencePath="$(IntersectionAssemblyReferencePath)"
 			ExcludeType="$(IntersectionExcludeType)"
+			RemoveAbstractTypeMembers="$(IntersectionRemoveAbstractTypeMembers)"
 			KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
 			KeepMarshalling="$(IntersectionKeepMarshalling)"
 			ToolPath="$(ApiIntersectToolPath)"


### PR DESCRIPTION
Added support for all ApiIntersect parameters. They can all now be specified from an MSBuild project.

Added the intersection assembly directories as the default directories to use when ApiIntersect tries to resolve assemblies. This allows ApiIntersect to resolve assemblies that are referenced by the project but it may still fail if there are public types exposed from the resolved assembly that are not removed by ApiIntersect.
 
https://github.com/NuGet/Home/issues/4597