### PR TITLE
Ensuring the LegacyCSProject is used for NuProj

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2017 RC
 
 init:
 - ps: >-

--- a/src/VisualStudio/NuGet.Client.Fix/LegacyCSProjProviderForNuProj.cs
+++ b/src/VisualStudio/NuGet.Client.Fix/LegacyCSProjProviderForNuProj.cs
@@ -1,0 +1,47 @@
+﻿using NuGet.PackageManagement.VisualStudio;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnvDTE;
+using NuGet.ProjectManagement;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
+
+namespace NuGet.Client.Fix
+{
+	[Export(typeof(IProjectSystemProvider))]
+	[Name(nameof(LegacyCSProjProviderForNuProj))]
+	[Order(Before = nameof(LegacyCSProjPackageReferenceProjectProvider))]
+	class LegacyCSProjProviderForNuProj : IProjectSystemProvider
+	{
+		// Reason it's lazy<object> is because we don't want to load any CPS assemblies untill
+		// we're really going to use any of CPS api. Which is why we also don't use nameof or typeof apis.
+		[Import("Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor")]
+		private Lazy<object> ProjectServiceAccessor { get; set; }
+
+		public bool TryCreateNuGetProject(Project dteProject, ProjectSystemProviderContext context, out NuGetProject result)
+		{
+			ThreadHelper.ThrowIfNotOnUIThread();
+
+			result = null;
+
+			var project = new EnvDTEProjectAdapter(dteProject);
+
+			if (VsHierarchyUtility.ToVsHierarchy(dteProject).IsCapabilityMatch("PackagingProject"))
+			{
+				// Lazy load the CPS enabled JoinableTaskFactory for the UI.
+				NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor);
+
+				result = new LegacyCSProjPackageReferenceProject(
+					project,
+					VsHierarchyUtility.GetProjectId(dteProject));
+
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/VisualStudio/NuGet.Client.Fix/NuGet.Client.Fix.csproj
+++ b/src/VisualStudio/NuGet.Client.Fix/NuGet.Client.Fix.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Client.Fix</RootNamespace>
+    <AssemblyName>NuGet.Client.Fix</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetExtensionPath>$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\NuGet</NuGetExtensionPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NuGet.PackageManagement.VisualStudio">
+      <HintPath>$(NuGetExtensionPath)\NuGet.PackageManagement.VisualStudio.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.VisualStudio.Facade">
+      <HintPath>$(NuGetExtensionPath)\NuGet.VisualStudio.Facade.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LegacyCSProjProviderForNuProj.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/VisualStudio/NuGet.Client.Fix/Properties/AssemblyInfo.cs
+++ b/src/VisualStudio/NuGet.Client.Fix/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.Client.Fix")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NuGet.Client.Fix")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7454a1ec-4033-4803-97c8-f0c8c04dbe4d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/VisualStudio/NuGet.Client.Fix/project.json
+++ b/src/VisualStudio/NuGet.Client.Fix/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "dependencies": {
+    "Microsoft.VisualStudio.Shell.14.0": "14.3.25407",
+    "Microsoft.VisualStudio.ProjectSystem.SDK": "15.0.594-pre",
+    "NuGet.PackageManagement": "4.0.0-*",
+    "VSSDK.DTE.8": "8.0.4",
+    "VSSDK.ComponentModelHost.11": "11.0.4",
+    "Microsoft.VisualStudio.CoreUtility": "15.0.26201"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.14/NuGet.Packaging.VisualStudio.14.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.14/NuGet.Packaging.VisualStudio.14.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetVsixContainerName>NuGetizer3000-VS2015.vsix</TargetVsixContainerName>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
-	<DeployExtension Condition="'$(DeployExtension)' == '' And '$(Configuration)' == 'Release'">false</DeployExtension>
+    <DeployExtension Condition="'$(DeployExtension)' == '' And '$(Configuration)' == 'Release'">false</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
@@ -82,6 +82,10 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NuGet.Client.Fix\NuGet.Client.Fix.csproj">
+      <Project>{7454a1ec-4033-4803-97c8-f0c8c04dbe4d}</Project>
+      <Name>NuGet.Client.Fix</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.Packaging.VisualStudio\NuGet.Packaging.VisualStudio.csproj">
       <Project>{9617edcd-23bb-41ea-827d-f5729d45b0af}</Project>
       <Name>NuGet.Packaging.VisualStudio</Name>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/project.json
@@ -9,7 +9,7 @@
 		"Microsoft.VisualStudio.ProjectSystem.SDK": "15.0.594-pre",
 		"Microsoft.VisualStudio.Shell.14.0": "14.3.25407",
 		"Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
-		"Microsoft.VSSDK.BuildTools": "15.0.25929-RC2",
+		"Microsoft.VSSDK.BuildTools": "15.0.26201",
 		"MSBuilder.DumpItems": "0.2.1",
 		"MSBuilder.Introspect": "0.1.5",
 		"MSBuilder.ThisAssembly.Project": "0.3.1",

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
@@ -15,6 +15,7 @@
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Packaging.VisualStudio" Path="|NuGet.Packaging.VisualStudio|"/>
 		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Packaging.VisualStudio.15" Path="|NuGet.Packaging.VisualStudio.15|"/>
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Client.Fix" Path="|NuGet.Client.Fix|"/>
 		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.Packaging.VisualStudio.15" Path="|NuGet.Packaging.VisualStudio.15;PkgdefProjectOutputGroup|" />
 		<Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="NuGet.Packaging.VisualStudio.15" Path="Templates\Projects" d:VsixSubPath="Templates\Projects" />
 		<Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" Path="|NuGet.Packaging.VisualStudio|" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.sln
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Packaging.VisualStudi
 		{BFA9BCE1-030C-40F1-94FE-A421C6103344} = {BFA9BCE1-030C-40F1-94FE-A421C6103344}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Client.Fix", "NuGet.Client.Fix\NuGet.Client.Fix.csproj", "{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		NuGet.Packaging.VisualStudio.Shared\NuGet.Packaging.VisualStudio.Shared.projitems*{70d9bbbc-b982-4210-9f66-5a02aea268fe}*SharedItemsImports = 13
@@ -58,6 +60,10 @@ Global
 		{CD844274-2306-4273-8D2C-E1B040457D79}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD844274-2306-4273-8D2C-E1B040457D79}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD844274-2306-4273-8D2C-E1B040457D79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7454A1EC-4033-4803-97C8-F0C8C04DBE4D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There is an open bug in the NuGet.Client team which returns the MsMuild project (packages.config)
instead of the LegacyCSProject. Until that bug is fixed, we need to export our own IProjectSystemProvider
before the built-in to we can ensure the Legacy instance is used for us.