### PR TITLE
Moved HandlesOwnReload and OpenProjectFile capabilities to code

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/ProjectSystem/NuProjCapabilities.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/ProjectSystem/NuProjCapabilities.cs
@@ -1,18 +1,15 @@
 ﻿using Microsoft.VisualStudio.ProjectSystem;
 
-using System.Collections.Immutable;
-
 namespace NuGet.Packaging.VisualStudio
 {
     internal static class NuProjCapabilities
     {
-        public const string NuProj = "PackagingProject";
+		public const string NuProj = "PackagingProject";
 
-        public static readonly ImmutableHashSet<string> ProjectSystem = Empty.CapabilitiesSet.Union(new[]
-        {
-            NuProj,
-            ProjectCapabilities.ProjectConfigurationsDeclaredAsItems,
-            ProjectCapabilities.ReferencesFolder,
-        });
+		public const string HandlesOwnReload = ProjectCapabilities.HandlesOwnReload;
+		public const string OpenProjectFile = nameof(OpenProjectFile);
+
+		public const string DefaultCapabilities = HandlesOwnReload + "; " +
+												  OpenProjectFile;
     }
 }

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/ProjectSystem/NuProjUnconfiguredProject.cs
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/ProjectSystem/NuProjUnconfiguredProject.cs
@@ -14,7 +14,8 @@ namespace NuGet.Packaging.VisualStudio
                              Constants.Language,
                              Guids.PackageGuid,
                              PossibleProjectExtensions = Constants.ProjectExtension,
-                             ProjectTemplatesDir = @"..\..\Templates\Projects\NuProj")]
+                             ProjectTemplatesDir = @"..\..\Templates\Projects\NuProj",
+                             Capabilities = NuProjCapabilities.DefaultCapabilities)]
     internal sealed class NuProjUnconfiguredProject
     {
         [Import]

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Targets/NuGet.Packaging.Authoring.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Targets/NuGet.Packaging.Authoring.targets
@@ -84,9 +84,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                           VisualStudioWellKnownOutputGroups;
                           SingleFileGenerators;
                           DeclaredSourceItems;
-                          UserSourceItems;
-                          HandlesOwnReload;
-                          OpenProjectFile" />
+                          UserSourceItems" />
 
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />


### PR DESCRIPTION
In order to avoid: https://github.com/dotnet/roslyn-project-system/issues/1103

Fixes NuGet/Home#4728