### PR TITLE
Fix assembly embedding and initialization

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -5,6 +5,9 @@
   <PropertyGroup>
     <ProjectGuid>{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}</ProjectGuid>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <OutputType>Exe</OutputType>
+    <TargetExt>.dll</TargetExt>
+    <StartupObject>NuGet.Build.Packaging.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -58,6 +61,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ApiIntersect.cs" />
     <Compile Include="AssignPackagePath.cs" />
     <Compile Include="CreatePackage.cs" />
@@ -65,6 +71,7 @@
     <Compile Include="GenerateAssemblyInfo.cs" />
     <Compile Include="GetApiIntersectTargetPaths.cs" />
     <Compile Include="MetadataName.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Build/NuGet.Build.Packaging.Tasks/Program.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Program.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NuGet.Build.Packaging
+{
+	class Program
+	{
+		[STAThread]
+		public static void Main(string[] args) { }
+	}
+}

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -8,7 +8,7 @@ using NuGet.Build.Packaging;
 [assembly: AssemblyCopyright ("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyTitle(ThisAssembly.AssemblyName)]
+[assembly: AssemblyTitle(ThisAssembly.Project.AssemblyName)]
 
 
 #if DEBUG

--- a/src/NuGet.Build.Packaging.Shared.targets
+++ b/src/NuGet.Build.Packaging.Shared.targets
@@ -33,10 +33,6 @@ namespace $(ThisAssemblyNamespace)
 
 	<Import Project="$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets" Condition="Exists('$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets')" />
 
-	<ItemGroup Condition=" '$(NoGlobalAssemblyInfo)' != 'true' And '$(Language)' == 'C#' ">
-		<Compile Include="$(MSBuildThisFileDirectory)GlobalAssemblyInfo.cs" Condition="'$(BuildingProject)' == 'true'" />
-	</ItemGroup>
-
 	<PropertyGroup>
 		<NuGetPackagingTargetsImported>true</NuGetPackagingTargetsImported>
 	</PropertyGroup>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
@@ -15,7 +15,6 @@
 		<StartProgram Condition="'$(VisualStudioVersion)' &lt; '15.0'">$(MSBuildProgramFiles32)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\devenv.exe</StartProgram>
 		<StartProgram Condition="'$(VisualStudioVersion)' &gt;= '15.0'">$(VsInstallRoot)\Common7\IDE\devenv.exe</StartProgram>
 		<StartArguments>/rootsuffix exp</StartArguments>
-		<NoGlobalAssemblyInfo>true</NoGlobalAssemblyInfo>
 		<XmlNs>&lt;Namespace Prefix='vs' Uri='http://schemas.microsoft.com/developer/vstemplate/2005'/&gt;</XmlNs>
 	</PropertyGroup>
 


### PR DESCRIPTION
Even though the Fody.Costura team members argue otherwise, the embedding
and module initialization works just fine for libraries. So instead of
relying on our own fork of it, or switch to more involed ILRepack approach,
we simply add an entry point to the tasks assembly to make the tool
happy.

See https://github.com/Fody/Costura/blob/52630a7341e1a8193c0c208a1b9dd98d2096699c/src/Costura/ModuleWeaver.cs#L25