### PR TITLE
Use $(IsPackable) everywhere we read $(PackageId)

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -215,39 +215,40 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</PropertyGroup>
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
 		<Error Condition="'@(_NonNuGetizedProjectReference)' != ''"
-			   Code="NG0011"
-			   Text="Some project references cannot be properly packaged. Please install the NuGet.Build.Packaging package on the following projects: @(_NonNuGetizedProjectReference)." />
+				   Code="NG0011"
+				   Text="Some project references cannot be properly packaged. Please install the NuGet.Build.Packaging package on the following projects: @(_NonNuGetizedProjectReference)." />
 
 		<!-- PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
 			 NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
 			 current project. -->
+
 		<ItemGroup>
 			<PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')"
-                         Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
+							   Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary output -->
 				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<!-- Remove when https://github.com/Microsoft/msbuild/pull/1076 ships -->
 			<_DocumentationProjectOutputGroupOutput Include="@(DocumentationProjectOutputGroupOutput)"
-													Condition="'$(IncludeOutputsInPackage)' == 'true'">
+														  Condition="'$(IncludeOutputsInPackage)' == 'true'">
 				<FinalOutputPath Condition="$([System.IO.Path]::IsPathRooted('%(FinalOutputPath)')) == 'false'">$(MSBuildProjectDirectory)\%(FinalOutputPath)</FinalOutputPath>
 			</_DocumentationProjectOutputGroupOutput>
 			<PackageFile Include="@(_DocumentationProjectOutputGroupOutput -> '%(FinalOutputPath)')"
-                         Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
+							   Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary docs -->
 				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<PackageFile Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
-                         Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IncludeSymbolsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
+							   Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IncludeSymbolsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute primary symbols -->
 				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
 
 			<!-- Change to %(FinalOutputPath) when https://github.com/Microsoft/msbuild/pull/1115 ships -->
 			<PackageFile Include="@(SatelliteDllsProjectOutputGroupOutput -> '%(FullPath)')"
-						 Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
+							   Condition="'$(IncludeOutputsInPackage)' == 'true' and '$(IsPackagingProject)' != 'true'">
 				<!-- Packaging projects don't contribute satellite dlls -->
 				<Kind>$(PrimaryOutputPackageFileKind)</Kind>
 			</PackageFile>
@@ -255,13 +256,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<!-- NOTE: Content is opt-out (must have IncludeInPackage=false to exclude) -->
 			<!-- @ContentFilesProjectOutputGroupOutput = @(ContentWithTargetPath->'%(FullPath)') -->
 			<PackageFile Include="@(ContentFilesProjectOutputGroupOutput)"
-						 Condition="'$(IncludeContentInPackage)' == 'true' and '%(ContentFilesProjectOutputGroupOutput.IncludeInPackage)' != 'false'">
+							   Condition="'$(IncludeContentInPackage)' == 'true' and '%(ContentFilesProjectOutputGroupOutput.IncludeInPackage)' != 'false'">
 				<Kind>Content</Kind>
 			</PackageFile>
 
 			<!-- NOTE: None is opt-in (must have IncludeInPackage=true to include) -->
 			<PackageFile Include="@(_NoneWithTargetPath)"
-						 Condition="'%(_NoneWithTargetPath.IncludeInPackage)' == 'true'">
+							   Condition="'%(_NoneWithTargetPath.IncludeInPackage)' == 'true'">
 				<Kind>None</Kind>
 			</PackageFile>
 
@@ -273,13 +274,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 			     it also includes mscorlib which we don't need
 			     TBD: maybe include ResolvedFrom=ImplicitlyExpandDesignTimeFacades too? -->
 			<PackageFile Include="@(ReferencePath->'%(OriginalItemSpec)')"
-						 Condition="'$(IncludeFrameworkReferencesInPackage)' == 'true' and '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
+							   Condition="'$(IncludeFrameworkReferencesInPackage)' == 'true' and '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
 				<Kind>FrameworkReference</Kind>
 			</PackageFile>
 		</ItemGroup>
 
 		<!-- If packaging the project, provide the metadata as a non-file item -->
-		<ItemGroup Condition="'$(PackageId)' != ''">
+		<ItemGroup Condition="'$(IsPackable)' == 'true'">
 			<PackageFile Include="@(PackageTargetPath->'%(Id)')">
 				<Kind>Metadata</Kind>
 			</PackageFile>
@@ -287,7 +288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 		<ItemGroup>
 			<PackageFile>
-				<PackageId>$(PackageId)</PackageId>
+				<PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
 				<Platform>$(Platform)</Platform>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
 			</PackageFile>
@@ -298,40 +299,40 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</AssignPackagePath>
 
 		<MSBuild Projects="@(_NuGetizedProjectReference)"
-				 Targets="GetPackageContents"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_NuGetizedProjectReference.SetConfiguration); %(_NuGetizedProjectReference.SetPlatform); BuildingPackage=$(BuildingPackage)"
-				 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
-				 RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">
+					 Targets="GetPackageContents"
+					 BuildInParallel="$(BuildInParallel)"
+					 Properties="%(_NuGetizedProjectReference.SetConfiguration); %(_NuGetizedProjectReference.SetPlatform); BuildingPackage=$(BuildingPackage)"
+					 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
+					 RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">
 			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedPackageContent" />
 		</MSBuild>
 
 		<ItemGroup>
 			<_ReferencedPackageDependency Include="@(_ReferencedPackageContent)"
-										  Condition="'%(_ReferencedPackageContent.PackageId)' != '$(PackageId)' and '%(_ReferencedPackageContent.Kind)' == 'Metadata'">
+												Condition="'%(_ReferencedPackageContent.PackageId)' != '$(PackageId)' and '%(_ReferencedPackageContent.Kind)' == 'Metadata'">
 				<!-- For consistency, annotate like the rest -->
-				<PackageId>$(PackageId)</PackageId>
+				<PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
 				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
 				<Kind>Dependency</Kind>
 			</_ReferencedPackageDependency>
 			<!-- Remove the referenced package actual contents if it provides a manifest, since it will be a dependency in that case. -->
 			<_PackageContentFromDependency Include="@(_ReferencedPackageContent)"
-										   Condition="'%(_ReferencedPackageContent.PackageId)' != '' and 
+												 Condition="'%(_ReferencedPackageContent.PackageId)' != '' and 
 										              '%(_ReferencedPackageContent.PackageId)' != '$(PackageId)'" />
 			<_ReferencedPackageContent Remove="@(_PackageContentFromDependency)" />
 		</ItemGroup>
 
 		<!-- Always annotate package contents with the original target framework and moniker -->
 		<CreateItem Include="@(_ReferencedPackageContent)" PreserveExistingMetadata="true"
-					Condition="'@(_ReferencedPackageContent)' != ''"
-					AdditionalMetadata="OriginalTargetFramework=%(TargetFramework);OriginalTargetFrameworkMoniker=%(TargetFrameworkMoniker)">
+						Condition="'@(_ReferencedPackageContent)' != ''"
+						AdditionalMetadata="OriginalTargetFramework=%(TargetFramework);OriginalTargetFrameworkMoniker=%(TargetFrameworkMoniker)">
 			<Output TaskParameter="Include" ItemName="_ReferencedPackageContentWithOriginalValues"/>
 		</CreateItem>
 
 		<ItemGroup Condition="'$(IsPackagingProject)' != 'true'">
 			<!-- Retarget content for the currently building package, if necessary -->
 			<_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
-				<PackageId>$(PackageId)</PackageId>
+				<PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
 				<!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
 				<!-- Only do this for Library assets that come from project references that don't build nugets (PackageId=='' above) -->
 				<TargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib' or 
@@ -350,7 +351,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<ItemGroup Condition="'$(IsPackagingProject)' == 'true'">
 			<!-- Retarget content for the currently building package, if necessary -->
 			<_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
-				<PackageId>$(PackageId)</PackageId>
+				<PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
 				<!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
 				<!-- Only do this for Library assets that come from project references that don't build nugets (PackageId=='' above) -->
 				<TargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.Kind)' == 'Lib' or 
@@ -364,24 +365,24 @@ Copyright (c) .NET Foundation. All rights reserved.
 			 depend on the referencing project's TFM.
 		-->
 		<AssignPackagePath Files="@(_ReferencedPackageContentWithOriginalValues);@(_ReferencedPackageDependency)"
-						   Kinds="@(PackageItemKind)"
-						   IsPackaging="$(BuildingPackage)"
-						   Condition="'@(_ReferencedPackageContentWithOriginalValues)' != '' Or '@(_ReferencedPackageDependency)' != ''">
+							   Kinds="@(PackageItemKind)"
+							   IsPackaging="$(BuildingPackage)"
+							   Condition="'@(_ReferencedPackageContentWithOriginalValues)' != '' Or '@(_ReferencedPackageDependency)' != ''">
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
 	</Target>
 
 	<!-- This target separates project references that have the packaging targets from those that don't -->
 	<Target Name="_SplitProjectReferencesByIsNuGetized"
-			Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
-			Inputs="@(_MSBuildProjectReferenceExistent)"
-			Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
+			  Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
+			  Inputs="@(_MSBuildProjectReferenceExistent)"
+			  Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
 
 		<MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-				 Targets="GetTargetPathWithTargetPlatformMoniker"
-				 BuildInParallel="$(BuildInParallel)"
-				 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
-				 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+					 Targets="GetTargetPathWithTargetPlatformMoniker"
+					 BuildInParallel="$(BuildInParallel)"
+					 Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+					 RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectTargetPath" />
 		</MSBuild>
 
@@ -391,11 +392,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 		<ItemGroup>
 			<!-- We will fail for this first group: project references that aren't excluded from packaging, yet haven't been nugetized -->
-			<_NonNuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)" 
-										   Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' != 'true'" />
+			<_NonNuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)"
+												 Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' != 'true'" />
 			<!-- We will only process for packaging the project references that haven't been excluded from packaging and are nugetized -->
-			<_NuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)" 
-										Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' == 'true'" />
+			<_NuGetizedProjectReference Include="@(_MSBuildProjectReferenceExistent)"
+											  Condition="'%(_MSBuildProjectReferenceExistent.IncludeInPackage)' != 'false' and '$(_IsNuGetized)' == 'true'" />
 		</ItemGroup>
 
 	</Target>
@@ -491,15 +492,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ItemGroup>
 
 		<MSBuild
-			Projects="@(_ReferenceAssemblyProjects)"
-			Targets="GetTargetPathWithTargetPlatformMoniker">
+				Projects="@(_ReferenceAssemblyProjects)"
+				Targets="GetTargetPathWithTargetPlatformMoniker">
 			<Output TaskParameter="TargetOutputs" ItemName="IntersectionAssembly" />
 		</MSBuild>
 
 		<GetApiIntersectTargetPaths
-			Frameworks="%(ReferenceAssemblyFramework.Identity)"
-			RootOutputDirectory="$(IntermediateOutputPath)"
-			Assemblies="@(IntersectionAssembly)">
+				Frameworks="%(ReferenceAssemblyFramework.Identity)"
+				RootOutputDirectory="$(IntermediateOutputPath)"
+				Assemblies="@(IntersectionAssembly)">
 			<Output TaskParameter="TargetPaths" ItemName="_ReferenceAssemblyTargetPath" />
 		</GetApiIntersectTargetPaths>
 
@@ -512,10 +513,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</Target>
 
 	<Target Name="_GenerateReferenceAssemblies"
-		DependsOnTargets="_GetReferenceAssemblyTargetPaths"
-		Condition=" '@(ReferenceAssemblyFramework)' != '' "
-		Inputs="@(IntersectionAssembly)"
-		Outputs="@(_ReferenceAssemblyTargetPath)">
+		  DependsOnTargets="_GetReferenceAssemblyTargetPaths"
+		  Condition=" '@(ReferenceAssemblyFramework)' != '' "
+		  Inputs="@(IntersectionAssembly)"
+		  Outputs="@(_ReferenceAssemblyTargetPath)">
 
 		<PropertyGroup>
 			<EnableDefaultIntersectionAssemblyReferencePath Condition="'$(EnableDefaultIntersectionAssemblyReferencePath)' == ''">true</EnableDefaultIntersectionAssemblyReferencePath>
@@ -525,31 +526,31 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<_IntersectionReferencePath Include="@(IntersectionAssembly->'%(RootDir)%(Directory)')" Condition="'$(EnableDefaultIntersectionAssemblyReferencePath)' == 'true'" />
 			<_IntersectionReferencePath Include="$(IntersectionAssemblyReferencePath)" />
 		</ItemGroup>
-		
+
 		<ApiIntersect
-			Framework="%(ReferenceAssemblyFramework.Identity)"
-			RootOutputDirectory="$(IntermediateOutputPath)"
-			IntersectionAssembly="@(IntersectionAssembly)"
-			ReferencePath="@(_IntersectionReferencePath)"
-			ExcludeType="$(IntersectionExcludeType)"
-			RemoveAbstractTypeMembers="$(IntersectionRemoveAbstractTypeMembers)"
-			ExcludeAssembly="@(IntersectionExcludeAssembly)"
-			KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
-			KeepMarshalling="$(IntersectionKeepMarshalling)"
-			ToolPath="$(ApiIntersectToolPath)"
-			ToolExe="$(ApiIntersectToolExe)">
+				Framework="%(ReferenceAssemblyFramework.Identity)"
+				RootOutputDirectory="$(IntermediateOutputPath)"
+				IntersectionAssembly="@(IntersectionAssembly)"
+				ReferencePath="@(_IntersectionReferencePath)"
+				ExcludeType="$(IntersectionExcludeType)"
+				RemoveAbstractTypeMembers="$(IntersectionRemoveAbstractTypeMembers)"
+				ExcludeAssembly="@(IntersectionExcludeAssembly)"
+				KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
+				KeepMarshalling="$(IntersectionKeepMarshalling)"
+				ToolPath="$(ApiIntersectToolPath)"
+				ToolExe="$(ApiIntersectToolExe)">
 			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />
 		</ApiIntersect>
 
 		<GenerateAssemblyInfo
-			Assemblies="@(IntersectionAssembly)"
-			OutputDirectories="@(_ReferenceAssemblyBuildInfo->'%(Identity)Contract')">
+				Assemblies="@(IntersectionAssembly)"
+				OutputDirectories="@(_ReferenceAssemblyBuildInfo->'%(Identity)Contract')">
 			<Output TaskParameter="AssemblyName" PropertyName="_ReferenceAssemblyName" />
 		</GenerateAssemblyInfo>
 
 		<MSBuild
-			Projects="$(MSBuildThisFileDirectory)GenerateReferenceAssembly.csproj"
-			Properties="
+				Projects="$(MSBuildThisFileDirectory)GenerateReferenceAssembly.csproj"
+				Properties="
 				AssemblyName=$(_ReferenceAssemblyName);
 				SrcDir=%(_ReferenceAssemblyBuildInfo.FullPath);
 				OutputPath=%(_ReferenceAssemblyBuildInfo.FullPath)bin\;


### PR DESCRIPTION
At the top of the targets file, we default `$(IsPackable)` to true if `$(PackageId)` is
not empty. .NETStandard projects currently *always* assign a value to that property,
matching the `$(AssemblyName)`, therefore breaking our logic.

To improve compatibility, we can check for the `$(IsPackable)` property instead, so that
while more alignment is achieved, at least an explicit `$(IsPackable)==false` can be set
for those projects and keep our logic consistent in that case.

That involves never assuming the `$(PackageId)` will be empty before assigning it as
metadata on items, and always checking for `$(IsPackable)==true` instead.