### PR TITLE
Split GetPackageContents from the inference behavior for additional flexibility

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -197,24 +197,34 @@ Copyright (c) .NET Foundation. All rights reserved.
 	-->
 	<PropertyGroup>
 		<!-- Only depend on ResolveReferences if we need to include framework references -->
-		<GetPackageContentsDependsOn Condition="'$(IncludeFrameworkReferencesInPackage)' == 'true'">
+		<InferPackageContentsDependsOn Condition="'$(IncludeFrameworkReferencesInPackage)' == 'true'">
 			ResolveReferences
-		</GetPackageContentsDependsOn>
-		<GetPackageContentsDependsOn>
-			$(GetPackageContentsDependsOn);
+		</InferPackageContentsDependsOn>
+		<InferPackageContentsDependsOn>
+			$(InferPackageContentsDependsOn);
 			GetPackageTargetPath;
-			ReadLegacyDependencies;
-		</GetPackageContentsDependsOn>
-		<GetPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
-			$(GetPackageContentsDependsOn)
+			ReadLegacyDependencies
+		</InferPackageContentsDependsOn>
+		<InferPackageContentsDependsOn Condition="'$(IncludeOutputsInPackage)' == 'true'">
+			$(InferPackageContentsDependsOn);
 			AssignProjectConfiguration;
 			_SplitProjectReferencesByFileExistence;
 			_SplitProjectReferencesByIsNuGetized;
 			AllProjectOutputGroups;
-			_GetReferenceAssemblyTargetPaths;
-		</GetPackageContentsDependsOn>
+			_GetReferenceAssemblyTargetPaths
+		</InferPackageContentsDependsOn>
+		<GetPackageContentsDependsOn>InferPackageContents</GetPackageContentsDependsOn>
 	</PropertyGroup>
+	
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
+		<!-- We batch depending on the IsPackaging metadata, which is only specified for referenced content 
+			 if the current project is building a package, to force retargeting of the referenced content. -->
+		<AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)" IsPackaging="%(PackageFile.IsPackaging)">
+			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
+		</AssignPackagePath>
+	</Target>
+
+	<Target Name="InferPackageContents" DependsOnTargets="$(InferPackageContentsDependsOn)" Returns="@(PackageFile)">
 		<Error Condition="'@(_NonNuGetizedProjectReference)' != ''"
 				   Code="NG0011"
 				   Text="Some project references cannot be properly packaged. Please install the NuGet.Build.Packaging package on the following projects: @(_NonNuGetizedProjectReference)." />
@@ -295,10 +305,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</PackageFile>
 		</ItemGroup>
 
-		<AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)">
-			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
-		</AssignPackagePath>
-
 		<MSBuild Projects="@(_NuGetizedProjectReference)"
 					 Targets="GetPackageContents"
 					 BuildInParallel="$(BuildInParallel)"
@@ -361,16 +367,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 			</_ReferencedPackageContentWithOriginalValues>
 		</ItemGroup>
 
-		<!-- Ensure referenced package content gets assigned a package path if it didn't provide one already.
-			 This happens for project references' that don't have a PackageId, since their package path will 
-			 depend on the referencing project's TFM.
-		-->
-		<AssignPackagePath Files="@(_ReferencedPackageContentWithOriginalValues);@(_ReferencedPackageDependency)"
-							   Kinds="@(PackageItemKind)"
-							   IsPackaging="$(BuildingPackage)"
-							   Condition="'@(_ReferencedPackageContentWithOriginalValues)' != '' Or '@(_ReferencedPackageDependency)' != ''">
-			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
-		</AssignPackagePath>
+		<ItemGroup>
+			<!-- Ensure referenced package content gets assigned a package path if it didn't provide one already.
+				 This happens for project references' that don't have a PackageId, since their package path will 
+				 depend on the referencing project's TFM.
+			-->
+			<PackageFile Include="@(_ReferencedPackageContentWithOriginalValues);@(_ReferencedPackageDependency)">
+				<IsPackaging>$(BuildingPackage)</IsPackaging>
+			</PackageFile>
+		</ItemGroup>
 	</Target>
 
 	<!-- This target separates project references that have the packaging targets from those that don't -->

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.props
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.props
@@ -3,13 +3,6 @@
 	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 
 	<PropertyGroup>
-		<!-- This will be the right path when we run from xunit in the bin/$(Configuration) folder -->
-		<NuGetTargetsPath Condition="'$(NuGetTargetsPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.props))</NuGetTargetsPath>
-		<!-- This will be the right path when we run from MSBuild from the source location inside the tests project -->
-		<NuGetTargetsPath Condition="!Exists('$(NuGetTargetsPath)\NuGet.Build.Packaging.props')">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Packaging.Tasks\bin\Debug</NuGetTargetsPath>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
 		<OutputPath>bin\$(MSBuildProjectName)</OutputPath>
@@ -47,6 +40,11 @@
 		<!-- Required package metadata -->
 		<Authors>NuGet</Authors>
 		<Description>Package for '$(MSBuildProjectName)' project.</Description>
+
+		<!-- This will be the right path when we run from xunit in the bin/$(Configuration) folder -->
+		<NuGetTargetsPath Condition="'$(NuGetTargetsPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.props))</NuGetTargetsPath>
+		<!-- This will be the right path when we run from MSBuild from the source location inside the tests project -->
+		<NuGetTargetsPath Condition="!Exists('$(NuGetTargetsPath)\NuGet.Build.Packaging.props')">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Packaging.Tasks\bin\$(Configuration)</NuGetTargetsPath>
 	</PropertyGroup>
 
 	<Import Project="$(NuGetTargetsPath)\NuGet.Build.Packaging.props" Condition="Exists('$(NuGetTargetsPath)\NuGet.Build.Packaging.props')" />

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_content/library_with_content.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_library_with_content/library_with_content.csproj
@@ -29,4 +29,9 @@
 	</ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), fakeframework.targets))\fakeframework.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
+	<Target Name="RemoveContent" Condition="'$(RemoveContent)' == 'true'" BeforeTargets="GetPackageContents">
+		<ItemGroup>
+			<PackageFile Remove="@(PackageFile)" Condition="'%(Kind)' == 'Content' Or '%(Kind)' == 'None'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_library_with_config_dependencies/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_library_with_config_dependencies/a.csproj
@@ -82,9 +82,9 @@
 	<!-- From the gazillion added packages to packages.config, we only need to keep the top level Microsoft.CodeAnalysis -->
 	<Target Name="RemoveUnnecessaryDependencies" BeforeTargets="GetPackageContents" Condition="'@(PackageReference)' != ''">
 		<ItemGroup>
-			<_CodeAnalysisDependency Include="@(PackageReference)"
-									 Condition="$([System.String]::new(%(Identity)).StartsWith('Microsoft.CodeAnalysis.'))" />
-			<PackageReference Remove="@(_CodeAnalysisDependency)" />
+			<_CodeAnalysisDependency Include="@(PackageFile)"
+									 Condition="'%(Kind)' == 'Dependency' And $([System.String]::new(%(Identity)).StartsWith('Microsoft.CodeAnalysis.'))" />
+			<PackageFile Remove="@(_CodeAnalysisDependency)" />
 		</ItemGroup>
 	</Target>
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_library_with_json_dependencies/a.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_library_with_json_dependencies/a.csproj
@@ -11,7 +11,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />
 	<Target Name="RemoveIFluentInterface" BeforeTargets="GetPackageContents">
 		<ItemGroup>
-			<PackageReference Remove="IFluentInterface" />
+			<PackageFile Remove="IFluentInterface" />
 		</ItemGroup>
 	</Target>
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_content.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_content.cs
@@ -92,7 +92,7 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
-		public void when_none_item_has_include_in_package_false_then_it_is_included()
+		public void when_none_item_has_include_in_package_false_then_it_is_not_included()
 		{
 			var result = Builder.BuildScenario(nameof(given_a_library_with_content), new
 			{
@@ -137,6 +137,20 @@ namespace NuGet.Build.Packaging
 			{
 				TargetPath = "content-with-include-true.txt",
 			}));
+		}
+
+		[Fact]
+		public void when_removing_inferred_package_file_from_content_then_content_is_not_included()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_library_with_content), new
+			{
+				PackageId = "ContentPackage",
+				RemoveContent = "true",
+			});
+
+			result.AssertSuccess(output);
+
+			Assert.DoesNotContain(result.Items, item => item.GetMetadata("PackagePath").StartsWith("contentFiles"));
 		}
 	}
 }

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
@@ -8,7 +8,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Shared.targets))\NuGet.Build.Packaging.Shared.targets" />
 
 	<PropertyGroup>
-		<DeployExtension Condition="'$(Configuration)' != 'Debug' Or '$(VisualStudioVersion)' != '$(TargetVSVersion)'" >false</DeployExtension>
+		<DeployExtension Condition="'$(Configuration)' != 'Debug'">false</DeployExtension>
 		<SkipValidatePackageReferences>true</SkipValidatePackageReferences>
 		
 		<StartAction>Program</StartAction>


### PR DESCRIPTION
This allows targets that run BeforeTargets=GetPackageContents to also tweak the
@(PackageFile) with the inferred items before they are assigned a target path and
passed down to Pack.

This makes the mechanism even more flexible. Accompanying documentation update on
the wiki done too.