### PR TITLE
Make Pack depend on Build when project is packable

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -451,12 +451,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<BuildDependsOn Condition="('$(PackOnBuild)' == 'true' Or Exists('$(PackOnBuildFile)')) and '$(IsPackable)' == 'true'">
+		<!-- If we're packing on build, just add Pack as a dependency for Build -->
+		<_ShouldPackOnBuild Condition="('$(PackOnBuild)' == 'true' Or Exists('$(PackOnBuildFile)')) And '$(IsPackable)' == 'true'">true</_ShouldPackOnBuild>
+		<BuildDependsOn Condition="'$(_ShouldPackOnBuild)' == 'true'">
 			$(BuildDependsOn);
 			Pack;
 		</BuildDependsOn>
-		<PackDependsOn Condition="'$(IsPackagingProject)' != 'true'">
-			CoreBuild;
+		<!-- If we're not packing on build, set up a dependency from Pack>Build for non-NuProj that are packable, so Build runs before Pack -->
+		<PackDependsOn Condition="'$(IsPackagingProject)' != 'true' And '$(_ShouldPackOnBuild)' != 'true' And '$(IsPackable)' == 'true'">
+			Build;
 		</PackDependsOn>
 		<PackDependsOn>
 			$(PackDependsOn)


### PR DESCRIPTION
We were previously depending on just CoreBuild. Make it so that doing a
`msbuild /p:PackOnBuild=true` == `msbuild /t:Pack`, which should fix
issue https://github.com/NuGet/Home/issues/4777