### PR TITLE
Resetting the TF in the targets used by VS

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio/Targets/NuGet.Packaging.Authoring.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio/Targets/NuGet.Packaging.Authoring.targets
@@ -16,7 +16,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <ProjectSystemRulesDir Condition="'$(ProjectSystemRulesDir)' == ''">$(MSBuildThisFileDirectory)..\Rules\</ProjectSystemRulesDir>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <!-- Inside Visual Studio, TF must be empty to bypass the CPS-based restore mechanism -->
+    <TargetFramework></TargetFramework>
     <PackageTargetFallback>net11;net20;net35;net40;net403;net45;net451;net452;net46;net461;net462;netcore;netcore45;netcore451;netcore50;win8;win81;win10;sl4;sl5;wp;wp7;wp75;wp8;wp81;wpa81;uap;uap10;netstandard1.0;netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.4;netstandard1.5;netstandard1.6;netstandard2.0;netcoreapp1.0;netcoreapp2.0;monoandroid;monotouch;monomac;xamarinios;xamarinmac;xamarinpsthree;xamarinpsfour;xamarinpsvita;xamarinwatchos;xamarintvos;xamarinxboxthreesixty;xamarinxboxone</PackageTargetFallback>
   </PropertyGroup>
 


### PR DESCRIPTION
TF must be empty to bypass the CpsPackageReferenceProjectProvider:

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs

and being correctly created by the LegacyCSProjPackageReferenceProjectProvider

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs

The CPS-based provider can't be used because it's expecting the ProjectRestoreInfo stuff provided (only for now) by the Roslyn project system

On the other hand, we MUST need the TF value when the project is being restored from cmd-line.