### PR TITLE
Only default IncludeFrameworkReferencesInPackage to true for libs

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -40,10 +40,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == '' and '$(IncludeOutputsInPackage)' == 'true' and '$(Configuration)' == 'Debug'">true</IncludeSymbolsInPackage>
 		<!-- Whether to include framework references (%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}') in the package -->
 
-		<!-- Only default to true if the project isn't a nuget packaging project itself. -->
-		<_DefaultIncludeFrameworkReferencesInPackage Condition="'$(PrimaryOutputPackageFileKind)' == 'build' Or '$(PrimaryOutputPackageFileKind)' == 'tool' Or '$(PrimaryOutputPackageFileKind)' == 'tools'">false</_DefaultIncludeFrameworkReferencesInPackage>
-		<_DefaultIncludeFrameworkReferencesInPackage Condition="'$(_DefaultIncludeFrameworkReferencesInPackage)' == ''">true</_DefaultIncludeFrameworkReferencesInPackage>
-		<IncludeFrameworkReferencesInPackage Condition="'$(IncludeFrameworkReferencesInPackage)' == '' and '$(IsPackagingProject)' != 'true'">$(_DefaultIncludeFrameworkReferencesInPackage)</IncludeFrameworkReferencesInPackage>
+		<!-- Only default to true if the project isn't a nuget packaging project itself and its primary output is lib. -->
+		<IncludeFrameworkReferencesInPackage Condition="'$(IncludeFrameworkReferencesInPackage)' == '' and '$(IsPackagingProject)' != 'true' and '$(PrimaryOutputPackageFileKind)' == 'Lib'">true</IncludeFrameworkReferencesInPackage>
 
 		<PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">false</PackageRequireLicenseAcceptance>
 

--- a/src/Build/NuGet.Build.Packaging.Tests/TargetsTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/TargetsTests.cs
@@ -17,40 +17,51 @@ namespace NuGet.Build.Packaging
 		public TargetsTests(ITestOutputHelper output) => this.output = output;
 
 		[Fact]
-		public void IncludeFrameworkReferencesInPackage_defaults_to_false_for_build_primary_output()
+		public void IncludeFrameworkReferencesInPackage_is_not_true_for_build_primary_output()
 		{
 			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
 			{
 				{ "PrimaryOutputPackageFileKind", "build" }
 			}, "14.0");
 
-			Assert.Equal("false", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
+			Assert.NotEqual("true", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
 		}
 
 		[Fact]
-		public void IncludeFrameworkReferencesInPackage_defaults_to_false_for_tool_primary_output()
+		public void IncludeFrameworkReferencesInPackage_is_not_true_for_tool_primary_output()
 		{
 			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
 			{
 				{ "PrimaryOutputPackageFileKind", "tool" }
 			}, "14.0");
 
-			Assert.Equal("false", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
+			Assert.NotEqual("true", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
 		}
 
 		[Fact]
-		public void IncludeFrameworkReferencesInPackage_defaults_to_false_for_tools_primary_output()
+		public void IncludeFrameworkReferencesInPackage_is_not_true_for_tools_primary_output()
 		{
 			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
 			{
 				{ "PrimaryOutputPackageFileKind", "tools" }
 			}, "14.0");
 
-			Assert.Equal("false", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
+			Assert.NotEqual("true", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
 		}
 
 		[Fact]
-		public void IncludeFrameworkReferencesInPackage_defaults_to_true_for_default_primary_output()
+		public void IncludeFrameworkReferencesInPackage_is_true_for_primary_output_lib()
+		{
+			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
+			{
+				{ "PrimaryOutputPackageFileKind", "lib" }
+			}, "14.0");
+
+			Assert.Equal("true", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
+		}
+
+		[Fact]
+		public void IncludeFrameworkReferencesInPackage_is_true_for_default_primary_output_kind()
 		{
 			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
 			{
@@ -60,14 +71,14 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
-		public void IncludeFrameworkReferencesInPackage_defaults_to_false_for_compat_istool()
+		public void IncludeFrameworkReferencesInPackage_is_not_true_for_compat_istool()
 		{
 			var project = new Project("NuGet.Build.Packaging.targets", new Dictionary<string, string>
 			{
 				{ "IsTool", "true" }
 			}, "14.0");
 
-			Assert.Equal("false", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
+			Assert.NotEqual("true", project.GetPropertyValue("IncludeFrameworkReferencesInPackage"));
 		}
 
 		[Fact]


### PR DESCRIPTION
Improves the fix for https://github.com/NuGet/Home/issues/5110