### PR TITLE
Update the original ProjectReference item definition for P2P support in nuproj

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
@@ -26,11 +26,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 			 documented escape hatch, see 
 			 https://github.com/Microsoft/msbuild/blob/2634f05a660b14c64ae4e924d900dd200d5032e7/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1537
 		-->
-		<_MSBuildProjectReferenceExistent>
+		<ProjectReference>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<AdditionalProperties>FromPackagingProject=true</AdditionalProperties>
-		</_MSBuildProjectReferenceExistent>
+		</ProjectReference>
 	</ItemDefinitionGroup>
 
 	<!-- Just to make it easy for consumers to request the TargetPath as usual but get the 


### PR DESCRIPTION
Rather than relying on the internal item group name `_MSBuildProjectReferenceExistent`, 
just modify the original `ProjectReference`, which works too since the metadata is passed 
down to the internal `_MSBuildProjectReferenceExistent` when that item group is determined.