### PR TITLE
Enable emitting the nuspec for troubleshooting purposes

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -24,6 +24,8 @@ namespace NuGet.Build.Packaging.Tasks
 		[Required]
 		public string TargetPath { get; set; }
 
+		public string NuspecFile { get; set; }
+
 		[Output]
 		public ITaskItem OutputPackage { get; set; }
 
@@ -112,7 +114,7 @@ namespace NuGet.Build.Packaging.Tasks
 								   Version = VersionRange.Parse(item.GetMetadata(MetadataName.Version)),
 								   TargetFramework = item.GetNuGetTargetFramework()
 							   };
-
+			
 			manifest.Metadata.DependencyGroups = (from dependency in dependencies
 												  group dependency by dependency.TargetFramework into dependenciesByFramework
 												  select new PackageDependencyGroup
@@ -190,6 +192,15 @@ namespace NuGet.Build.Packaging.Tasks
 				new PhysicalPackageFile { SourcePath = file.Source, TargetPath = file.Target }));
 			
 			builder.Save(output);
+
+			if (!string.IsNullOrEmpty(NuspecFile))
+			{
+				Directory.CreateDirectory(Path.GetDirectoryName(NuspecFile));
+				using (var stream = File.Create(NuspecFile))
+				{
+					manifest.Save(stream, true);
+				}
+			}
 		}
 
 		static VersionRange AggregateVersions(VersionRange aggregate, VersionRange next)

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -35,6 +35,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 		<!-- This file signals that the Build should actually do a Pack. Supports the IDE solution-wide Build command for authoring projects. -->
 		<PackOnBuildFile>$(MSBuildProjectDirectory)\.packonbuild</PackOnBuildFile>
+
+		<!-- Whether to emit the nuspec that's used to create the final package -->
+		<EmitNuSpec Condition="'$(EmitNuSpec)' == ''">false</EmitNuSpec>
+		<NuspecFile Condition="'$(NuspecFile)' == ''">$(OutputPath)\$(PackageId).nuspec</NuspecFile>
 	</PropertyGroup>
 
 	<Import Project="NuGet.Build.Packaging.Inference.targets" Condition="'$(InferPackageContents)' != 'false'" />
@@ -364,7 +368,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 	-->
 	<Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Returns="@(PackageTargetPath)" Condition="'$(IsPackable)' == 'true'">
 		<MakeDir Directories="$(PackageOutputPath)" Condition="!Exists('$(PackageOutputPath)')" />
-		<CreatePackage Manifest="@(PackageTargetPath)" Contents="@(_PackageContent)" TargetPath="@(PackageTargetPath->'%(FullPath)')">
+		<PropertyGroup>
+			<NuspecFile Condition="'$(EmitNuspec)' == 'true' And '$(NuspecFile)' ==''">$(OutputPath)\$(PackageId).nuspec</NuspecFile>
+		</PropertyGroup>
+		<CreatePackage Manifest="@(PackageTargetPath)" NuspecFile="$(NuspecFile)" Contents="@(_PackageContent)" TargetPath="@(PackageTargetPath->'%(FullPath)')">
 			<Output TaskParameter="OutputPackage" ItemName="_PackageTargetPath" />
 			<Output TaskParameter="OutputPackage" ItemName="FileWrites" />
 		</CreatePackage>

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -189,20 +189,17 @@ namespace NuGet.Build.Packaging
 				}),
 			};
 
+			task.NuspecFile = Path.GetTempFileName();
+			createPackage = Debugger.IsAttached;
+
 			var manifest = ExecuteTask();
+
+			Process.Start("notepad.exe", task.NuspecFile);
 
 			Assert.NotNull(manifest);
 			Assert.Equal(4, manifest.Metadata.DependencyGroups.Count());
 			Assert.All(manifest.Metadata.DependencyGroups, d => Assert.Empty(d.Packages));
-
-			//Assert.Equal(NuGetFramework.Parse(".NETFramework,Version=v4.5"), manifest.Metadata.DependencyGroups.First().TargetFramework);
-			//Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
-			//Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
-
-			//// We get a version range actually for the specified dependency, like [1.0.0,)
-			//Assert.Equal("8.0.0", manifest.Metadata.DependencyGroups.First().Packages.First().VersionRange.MinVersion.ToString());
 		}
-
 
 		[Fact]
 		public void when_creating_package_with_development_dependency_then_does_not_generate_dependency_group()


### PR DESCRIPTION
Setting the $(EmitNuspec) will cause the creation of the nuspec
in the default location of `$(OutputPath)\$(PackageId).nuspec`,
unless overriden by an (SDK Pack compatible) `NuspecFile` property.