### PR TITLE
Add support for specifying framework-agnostic dependencies

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/Extensions.cs
@@ -60,6 +60,10 @@ namespace NuGet.Build.Packaging
 
 		public static NuGetFramework GetNuGetTargetFramework(this ITaskItem taskItem)
 		{
+			if (bool.TryParse(taskItem.GetMetadata(MetadataName.FrameworkSpecific), out var frameworkSpecific) &&
+				!frameworkSpecific)
+				return NuGetFramework.AnyFramework;
+
 			var metadataValue = taskItem.GetMetadata(MetadataName.TargetFramework);
 			if (string.IsNullOrEmpty(metadataValue))
 				metadataValue = taskItem.GetMetadata(MetadataName.TargetFrameworkMoniker);


### PR DESCRIPTION
Can either use:
- FrameworkSpecific=false
- Set TargetFramework=any

NOTE: when a dependency group has no TF, instead of returning
NuGetFramework.Any, the NuGet API returns NuGetFramework.UnsupportedFramework :\

Fixes https://github.com/NuGet/Home/issues/5345