### PR TITLE
Building packages fails under 15.3 preview

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/FodyWeavers.xml
+++ b/src/Build/NuGet.Build.Packaging.Tasks/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers>
-	<Costura />
-</Weavers>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -5,18 +5,14 @@
   <PropertyGroup>
     <ProjectGuid>{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}</ProjectGuid>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <OutputType>Exe</OutputType>
-    <TargetExt>.dll</TargetExt>
-    <StartupObject>NuGet.Build.Packaging.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="1.3.3" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="1.29.4" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="1.1.61" PrivateAssets="all" />
+    <PackageReference Include="ILRepack" Version="2.0.13" PrivateAssets="all" />
     <PackageReference Include="netfx-System.StringResources" Version="3.0.14" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" Version="14.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0" PrivateAssets="all" />
@@ -27,7 +23,6 @@
     <PackageReference Include="NuGet.ProjectManagement" Version="4.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
     <Content Include="NuGet.Build.Packaging.props" />
     <Content Include="NuGet.Build.Packaging.targets" />
     <Content Include="NuGet.Build.Packaging.CrossTargeting.targets" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
@@ -105,4 +105,36 @@ namespace $(RootNamespace)
 		</ItemGroup>
 	</Target>
 
+	<Target Name="ILRepack"
+			AfterTargets="CoreCompile"
+			DependsOnTargets="CoreCompile"
+			Returns="@(MergedAssemblies)"
+			Condition="'$(ILRepack)' != 'false'">
+		<GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+			<Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
+		</GetReferenceAssemblyPaths>
+		<ItemGroup>
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Newtonsoft'))" />
+			<MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('NuGet'))" />
+			<ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+			<ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
+			<LibDir Include="@(ReferenceCopyLocalDirs->Distinct())" />
+		</ItemGroup>
+		<PropertyGroup>
+			<ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:&quot;$(AssemblyOriginatorKeyFile)&quot;</ILRepackArgs>
+		</PropertyGroup>
+		<Exec Command="&quot;$(ILRepack)&quot; @(LibDir->'/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
+			  WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)"
+			  StandardErrorImportance="high"
+			  StandardOutputImportance="low"
+			  ConsoleToMSBuild="true"
+			  ContinueOnError="true">
+			<Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput"/>
+			<Output TaskParameter="ExitCode" PropertyName="ExitCode"/>
+		</Exec>
+		<Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+		<Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+		<Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+	</Target>
+
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/App.config
+++ b/src/Build/NuGet.Build.Packaging.Tests/App.config
@@ -1,0 +1,23 @@
+﻿<configuration>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<!-- MSBuild 4 > 14 -->
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.cs
@@ -29,7 +29,7 @@ public static partial class Builder
 		//Environment.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1", EnvironmentVariableTarget.Process);
 		using (var manager = new BuildManager(Guid.NewGuid().ToString()))
 		{
-			var request = new BuildRequestData(project, targets.Split(','), null);
+			var request = new BuildRequestData(project, targets.Split(','));
 			var parameters = new BuildParameters
 			{ 
 				GlobalProperties = properties,

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -13,22 +13,31 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="NuGet.Build.Packaging.Tasks">
+      <HintPath>..\NuGet.Build.Packaging.Tasks\bin\$(Configuration)\NuGet.Build.Packaging.Tasks.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="1.1.61" />
-    <PackageReference Include="Microsoft.Build" Version="14.3.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Build" Version="14.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.Dump" Version="*" />
     <PackageReference Include="MSBuilder.DumpItems" Version="*" />
     <PackageReference Include="MSBuilder.Introspect" Version="*" />
+    <PackageReference Include="System.IO.Compression">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.IO.Compression.ZipFile">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="NuGet.Client" Version="4.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="4.0.0" />
-    <PackageReference Include="NuGet.ProjectManagement" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="NuGet.Build.Packaging.Tests.targets" />
     <Content Include="Scenarios\given_a_custom_build_project\Readme.txt" />
     <Content Include="Scenarios\given_a_library_with_content\content-copy.txt" />
@@ -160,10 +169,6 @@
     <ProjectReference Include="..\..\..\external\ApiIntersect\ApiIntersect\ApiIntersect.csproj">
       <Project>{cd767d93-6c99-4d6a-a303-3c139a73400e}</Project>
       <Name>ApiIntersect</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj">
-      <Project>{a3d231d7-31e4-4a70-8cd1-7246c7d069f6}</Project>
-      <Name>NuGet.Build.Packaging.Tasks</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.targets
@@ -4,16 +4,22 @@
 	<PropertyGroup>
 		<!-- Prevents Fody.VerifyTask from running -->
 		<NCrunch>1</NCrunch>
+		<!-- Don't reference the Tasks project, we are referring to its binary output instead -->
+		<AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
 	</PropertyGroup>
-	
+
 	<Target Name="AfterBuild">
 		<ItemGroup>
 			<ScenarioFile Include="Scenarios\**\*.*" Exclude="Scenarios\**\bin\**\*.*;Scenarios\**\obj\**\*.*" />
+			<NuGetizer Include="..\NuGet.Build.Packaging.Tasks\bin\$(Configuration)\**\*.*" />
 		</ItemGroup>
 
 		<Copy SourceFiles="@(ScenarioFile)"
-				  DestinationFiles="@(ScenarioFile -> '$(OutputPath)Scenarios\%(RecursiveDir)%(Filename)%(Extension)')"
-				  SkipUnchangedFiles="true" />
+				DestinationFiles="@(ScenarioFile -> '$(OutputPath)Scenarios\%(RecursiveDir)%(Filename)%(Extension)')"
+				SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(NuGetizer)"
+				DestinationFiles="@(NuGetizer -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')"
+				SkipUnchangedFiles="true" />
 	</Target>
-  
+
 </Project>

--- a/src/Build/NuGet.Build.Packaging.sln
+++ b/src/Build/NuGet.Build.Packaging.sln
@@ -1,11 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26510.0
+VisualStudioVersion = 15.0.26602.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Build.Packaging.Tasks", "NuGet.Build.Packaging.Tasks\NuGet.Build.Packaging.Tasks.csproj", "{A3D231D7-31E4-4A70-8CD1-7246C7D069F6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BD16CBB5-BD47-4CC3-A9FD-7F1B9077455D}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\.editorconfig = ..\..\.editorconfig
 		..\..\appveyor.yml = ..\..\appveyor.yml
 		Before.NuGet.Build.Packaging.sln.targets = Before.NuGet.Build.Packaging.sln.targets
 		..\..\build.cmd = ..\..\build.cmd
@@ -21,6 +22,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Build.Packaging.Tests", "NuGet.Build.Packaging.Tests\NuGet.Build.Packaging.Tests.csproj", "{212952C3-22F5-4263-BF9B-B17316B3B3CA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A3D231D7-31E4-4A70-8CD1-7246C7D069F6} = {A3D231D7-31E4-4A70-8CD1-7246C7D069F6}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiIntersect", "..\..\external\ApiIntersect\ApiIntersect\ApiIntersect.csproj", "{CD767D93-6C99-4D6A-A303-3C139A73400E}"
 EndProject


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5356

Rolls back usage of Fody+Costura which isn't doing what we
need it to do, and use ILRepack instead, which reliable isolate
us from version mismatches.

Fixed the issues we had before with running tests in the IDE
properly so we can merge the IL on both debug and release builds.