### PR TITLE
Add support for extending package metadata item

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="netfx-System.StringResources" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" Version="14.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0" PrivateAssets="all" />
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.8" PrivateAssets="all" />
     <PackageReference Include="NuGet.Client" Version="4.0.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="4.0.0" PrivateAssets="all" />

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.targets
@@ -94,8 +94,10 @@ namespace $(RootNamespace)
 	<Target Name="ILRepack"
 			AfterTargets="CoreCompile"
 			DependsOnTargets="CoreCompile"
+			Inputs="@(IntermediateAssembly->'%(FullPath)')"
+			Outputs="$(IntermediateOutputPath)ilrepack.txt"
 			Returns="@(MergedAssemblies)"
-			Condition="'$(ILRepack)' != 'false'">
+			Condition="Exists(@(IntermediateAssembly->'%(FullPath)')) and '$(ILRepack)' != 'false'">
 		<GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
 			<Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
 		</GetReferenceAssemblyPaths>
@@ -109,6 +111,7 @@ namespace $(RootNamespace)
 		<PropertyGroup>
 			<ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:&quot;$(AssemblyOriginatorKeyFile)&quot;</ILRepackArgs>
 		</PropertyGroup>
+		<Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" />
 		<Exec Command="&quot;$(ILRepack)&quot; @(LibDir->'/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
 			  WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)"
 			  StandardErrorImportance="high"
@@ -119,6 +122,7 @@ namespace $(RootNamespace)
 			<Output TaskParameter="ExitCode" PropertyName="ExitCode"/>
 		</Exec>
 		<Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+		<Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
 		<Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
 		<Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
 	</Target>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -188,7 +188,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<PropertyGroup>
 		<GetPackageContentsDependsOn>
 			$(GetPackageContentsDependsOn);
-			GetPackageTargetPath
+			GetPackageTargetPath;
+			_AddPackageManifest
 		</GetPackageContentsDependsOn>
 		<GetPackageContentsDependsOn Condition="'$(IncludeProjectReferencesInPackage)' == 'true'">
 			$(GetPackageContentsDependsOn);
@@ -197,15 +198,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Returns="@(_PackageContent)">
-		<!-- If packaging the project, provide the metadata as a non-file item -->
 		<ItemGroup>
-			<PackageFile Include="@(PackageTargetPath->'%(Id)')" Condition="'$(IsPackable)' == 'true'">
-				<Kind>Metadata</Kind>
-				<PackageId>$(PackageId)</PackageId>
-				<Platform>$(Platform)</Platform>
-				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
-			</PackageFile>
-
 			<!-- 
 				PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
 				NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
@@ -223,6 +216,18 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)" IsPackaging="%(PackageFile.IsPackaging)">
 			<Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
 		</AssignPackagePath>
+	</Target>
+
+	<Target Name="_AddPackageManifest" Condition="'$(IsPackable)' == 'true'">
+		<!-- If packaging the project, provide the metadata as a non-file item -->
+		<ItemGroup>
+			<PackageFile Include="@(PackageTargetPath->'%(Id)')" Condition="'$(IsPackable)' == 'true'">
+				<Kind>Metadata</Kind>
+				<PackageId>$(PackageId)</PackageId>
+				<Platform>$(Platform)</Platform>
+				<TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+			</PackageFile>
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_GetReferencedPackageContents"

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project/a.nuproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/given_a_packaging_project/a.nuproj
@@ -22,5 +22,12 @@
 			<Name>e</Name>
 		</ProjectReference>
 	</ItemGroup>
+	<Target Name="_AugmentMetadata" BeforeTargets="GetPackageContents">
+		<ItemGroup>
+			<PackageFile Condition="'%(PackageFile.Kind)' == 'Metadata'">
+				<Foo>Bar</Foo>
+			</PackageFile>
+		</ItemGroup>
+	</Target>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Scenario.targets))\Scenario.targets" />	
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_packaging_project.cs
@@ -41,6 +41,20 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
+		public void when_getting_contents_then_can_augment_package_metadata()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);
+
+			result.AssertSuccess(output);
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				Kind = "Metadata",
+				Foo = "Bar",
+			}));
+		}
+
+		[Fact]
 		public void when_getting_contents_then_includes_referenced_project_satellite_assembly()
 		{
 			var result = Builder.BuildScenario(nameof(given_a_packaging_project), target: "GetPackageContents", output: output);


### PR DESCRIPTION
This allows arbitrary additional metadata to be added to the package metadata
item for other purpose.

Fixes NuGet/Home#5387