### PR TITLE
Defined ProjectCapability ItemGroup when building outside of Visual Studio.

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
@@ -33,17 +33,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ProjectReference>
 	</ItemDefinitionGroup>
 
-  <!-- ProjectCapabilities in dev15 should be supported via NuGet packages -->
-  <ItemGroup>
-    <ProjectCapability Include="PackagingProject" />
+	<!-- ProjectCapabilities in dev15 should be supported via NuGet packages -->
+	<ItemGroup>
+		<ProjectCapability Include="PackagingProject" />
 
-    <!-- Allows configurations inferred from Condition="CONFIG|PLATFORM" usage -->
-    <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
+		<!-- Allows configurations inferred from Condition="CONFIG|PLATFORM" usage -->
+		<ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
 
-    <!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->
-    <ProjectCapability Include="DependenciesTree" />
+		<!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->
+		<ProjectCapability Include="DependenciesTree" />
 
-    <ProjectCapability Include="
+		<ProjectCapability Include="
                           AssemblyReferences;
                           ProjectReferences;
                           PackageReferences;
@@ -54,16 +54,16 @@ Copyright (c) .NET Foundation. All rights reserved.
                           DeclaredSourceItems;
                           UserSourceItems" />
 
-    <!-- Reference Manager capabilities -->
-    <ProjectCapability Include="ReferenceManagerAssemblies" />
-    <ProjectCapability Include="ReferenceManagerBrowse" />
-    <ProjectCapability Include="ReferenceManagerProjects" />
+		<!-- Reference Manager capabilities -->
+		<ProjectCapability Include="ReferenceManagerAssemblies" />
+		<ProjectCapability Include="ReferenceManagerBrowse" />
+		<ProjectCapability Include="ReferenceManagerProjects" />
 
-  </ItemGroup>
+	</ItemGroup>
 
-  <!-- Just to make it easy for consumers to request the TargetPath as usual but get the 
+	<!-- Just to make it easy for consumers to request the TargetPath as usual but get the 
 		 actual package file, which contains the PackageVersion and will be dynamic therefore. -->
-	<Target Name="UpdateTargetPath" 
+	<Target Name="UpdateTargetPath"
 			BeforeTargets="GetTargetPath"
 			DependsOnTargets="GetPackageTargetPath">
 		<PropertyGroup>
@@ -74,11 +74,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<Target Name="CoreCompile" DependsOnTargets="Pack" />
 	<Target Name="CreateManifestResourceNames" />
 	<Target Name="GetReferenceAssemblyPaths" />
-	
+
 	<Target Name="_CleanReferences" AfterTargets="ResolveAssemblyReferences">
 		<ItemGroup>
 			<ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
 		</ItemGroup>
 	</Target>
-	
+
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
@@ -33,7 +33,35 @@ Copyright (c) .NET Foundation. All rights reserved.
 		</ProjectReference>
 	</ItemDefinitionGroup>
 
-	<!-- Just to make it easy for consumers to request the TargetPath as usual but get the 
+  <!-- ProjectCapabilities in dev15 should be supported via NuGet packages -->
+  <ItemGroup>
+    <ProjectCapability Include="PackagingProject" />
+
+    <!-- Allows configurations inferred from Condition="CONFIG|PLATFORM" usage -->
+    <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
+
+    <!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->
+    <ProjectCapability Include="DependenciesTree" />
+
+    <ProjectCapability Include="
+                          AssemblyReferences;
+                          ProjectReferences;
+                          PackageReferences;
+                          OutputGroups;
+                          AllTargetOutputGroups;
+                          VisualStudioWellKnownOutputGroups;
+                          SingleFileGenerators;
+                          DeclaredSourceItems;
+                          UserSourceItems" />
+
+    <!-- Reference Manager capabilities -->
+    <ProjectCapability Include="ReferenceManagerAssemblies" />
+    <ProjectCapability Include="ReferenceManagerBrowse" />
+    <ProjectCapability Include="ReferenceManagerProjects" />
+
+  </ItemGroup>
+
+  <!-- Just to make it easy for consumers to request the TargetPath as usual but get the 
 		 actual package file, which contains the PackageVersion and will be dynamic therefore. -->
 	<Target Name="UpdateTargetPath" 
 			BeforeTargets="GetTargetPath"

--- a/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
+++ b/src/Build/NuGet.Build.Packaging.Tests/Scenarios/Scenario.targets
@@ -4,10 +4,11 @@
     <DocumentationFile Condition="'$(DocumentationFile)' == ''">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(IsPortable)' != 'true'" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(IsPortable)' != 'true' and '$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
-			Condition="'$(IsPortable)' == 'true'" />
-  <!-- Ensure we get proper NuGet behavior always -->
+			Condition="'$(IsPortable)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'" />  
+			
+	<!-- Ensure we get proper NuGet behavior always -->
   <Import Project="$(NuGetRestoreTargets)" Condition="'$(IsRestoreTargetsFileLoaded)' != 'true' and '$(NuGetRestoreTargets)' != ''" />
   <Import Project="$(NuGetTargets)" Condition="'$(ResolveNuGetPackageAssetsDependsOn)' == '' and '$(NuGetTargets)' != ''" />
 
@@ -95,5 +96,7 @@
       </Code>
     </Task>
   </UsingTask>
-
+  
+	<Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  
 </Project>


### PR DESCRIPTION
The ProjectCapability ItemGroup is not being defined when building outside of Visual Studio. This corrects that issue by duplicating the ProjectCapability ItemGroup definition into the Build/NuGet.Packaging.Authoring.targets file.

The "given_a_packaging_project" tests were hiding the issue by importing Microsoft.CSharp.targets into the packaging project. This caused the test to succeed because the CSharp targets were defining the ProjectCapability items.

These changes include a modification to Scenario.targets to ensure that Microsoft.CSharp.targets is only imported for ".csproj" projects.

Corrects NuGet/Home#5347