### PR TITLE
Readme: removed some extra Markdown characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Install the following package:
 
     Install-Package NuGet.Build.Packaging
 
-Add [NuGet properties to your MSBuild project](https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target) 
-) and invoke the `/t:Pack` target to generated a `.nupkg` for the project.
+Add [NuGet properties to your MSBuild project](https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target) and invoke the `/t:Pack` target to generated a `.nupkg` for the project.
 
 ## Issues
 


### PR DESCRIPTION
Saw a random ` )` in the rendered instructions Markdown that looked like a typo and removed it.