### PR TITLE
Properly add Clide as a dependency

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
@@ -60,8 +60,8 @@
     <PackageReference Include="MSBuilder.DumpItems" Version="0.2.1" />
     <PackageReference Include="MSBuilder.Introspect" Version="0.1.5" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" />
-    <PackageReference Include="MSBuilder.VsixDependency" Version="0.2.11" />
-    <PackageReference Include="MSBuilder.VsixInstaller" Version="0.2.16" />
+    <PackageReference Include="MSBuilder.VsixDependency" Version="0.2.13" />
+    <PackageReference Include="MSBuilder.VsixInstaller" Version="0.2.18" />
     <PackageReference Include="VSLangProj150" Version="1.0.0" />
     <PackageReference Include="VSSDK.ComponentModelHost.11" Version="11.0.4" />
   </ItemGroup>


### PR DESCRIPTION
When we bumped VsixDependency to properly account for VS2017
pre-requisite, we lost the plain Dependency nodes for non-component
VSIXes (Clide in our case). This caused our MEF exports to not be
available and the NuGet CPS exports to be missing, causing the nuproj
to fall back to packages.config behavior, which doesn't work.