### PR TITLE
Fix reference assembly generation

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -18,6 +18,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="**\*.props;**\*.targets" />
+    <Content Include="GenerateReferenceAssembly.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="NuGet.Build.Packaging.Tasks.targets" />
     <Content Include="**\*.props;**\*.targets" Exclude="obj\**\*.*;bin\**\*.*;NuGet.Build.Packaging.Tasks.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
When we switched to letting the new NuGetizer inference control
the package content, we missed adding the .csproj that generates
the reference assembly manually, since it's not added by default
as a Content item by the common targets.

Fixes https://github.com/NuGet/Home/issues/5465