### PR TITLE
Fix package file reference when CopyToOutput=Never

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Inference.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Inference.targets
@@ -107,23 +107,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 			<!-- NOTE: Content is opt-out (must have Pack=false to exclude if IncludeContentInPackage=true) -->
 			<!-- Stuff that is copied to output should be included from that output location -->
 			<_InferredPackageFile Include="@(_ContentToInfer->'$(OutputPath)%(TargetPath)')"
-							   Condition="'%(_ContentToInfer.CopyToOutputDirectory)' != ''">
+							   Condition="'%(_ContentToInfer.CopyToOutputDirectory)' != '' and '%(_ContentToInfer.CopyToOutputDirectory)' != 'Never'">
 				<Kind Condition="'%(_ContentToInfer.Kind)' == ''">$(PrimaryOutputKind)</Kind>
 			</_InferredPackageFile>
 			<!-- Otherwise, include from source location and default to content -->
 			<_InferredPackageFile Include="@(_ContentToInfer->'%(FullPath)')"
-							   Condition="'%(_ContentToInfer.CopyToOutputDirectory)' == ''">
+							   Condition="'%(_ContentToInfer.CopyToOutputDirectory)' == '' or '%(_ContentToInfer.CopyToOutputDirectory)' == 'Never'">
 				<Kind Condition="'%(_ContentToInfer.Kind)' == ''">Content</Kind>
 			</_InferredPackageFile>
 
 			<!-- NOTE: None is also opt-out (must have Pack=false to exclude if IncludeNoneInPackage=true, but this property defaults to false) -->
 			<!-- Likewise, include from target path if it's copied, from source path otherwise -->
 			<_InferredPackageFile Include="@(_NoneToInfer->'$(OutputPath)%(TargetPath)')"
-							   Condition="'%(_NoneToInfer.CopyToOutputDirectory)' != ''">
+							   Condition="'%(_NoneToInfer.CopyToOutputDirectory)' != '' and '%(_NoneToInfer.CopyToOutputDirectory)' != 'Never'">
 				<Kind Condition="'%(_NoneToInfer.Kind)' == ''">$(PrimaryOutputKind)</Kind>
 			</_InferredPackageFile>
 			<_InferredPackageFile Include="@(_NoneToInfer->'%(FullPath)')"
-							   Condition="'%(_NoneToInfer.CopyToOutputDirectory)' == ''">
+							   Condition="'%(_NoneToInfer.CopyToOutputDirectory)' == '' or '%(_NoneToInfer.CopyToOutputDirectory)' == 'Never'">
 				<Kind Condition="'%(_NoneToInfer.Kind)' == ''">None</Kind>
 			</_InferredPackageFile>
 

--- a/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/Builder.NuGetizer.cs
@@ -62,19 +62,22 @@ static partial class Builder
 		buildProps[nameof(ThisAssembly.Project.Properties.NuGetRestoreTargets)] = ThisAssembly.Project.Properties.NuGetRestoreTargets;
 		buildProps[nameof(ThisAssembly.Project.Properties.NuGetTargets)] = ThisAssembly.Project.Properties.NuGetTargets;
 
-		return new TargetResult(Build(projectOrSolution, target,
+		return new TargetResult(projectOrSolution, Build(projectOrSolution, target,
 			properties: buildProps,
 			logger: logger), target, logger);
 	}
 
 	public class TargetResult : ITargetResult
 	{
-		public TargetResult(BuildResult result, string target, TestOutputLogger logger)
+		public TargetResult(string projectOrSolutionFile, BuildResult result, string target, TestOutputLogger logger)
 		{
+			ProjectOrSolutionFile = projectOrSolutionFile;
 			BuildResult = result;
 			Target = target;
 			Logger = logger;
 		}
+
+		public string ProjectOrSolutionFile { get; private set; }
 
 		public BuildResult BuildResult { get; private set; }
 

--- a/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tests/NuGet.Build.Packaging.Tests.csproj
@@ -39,5 +39,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NuGet.Build.Packaging.Shared.targets))\NuGet.Build.Packaging.Shared.targets" />
 </Project>

--- a/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_content.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/given_a_library_with_content.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using Microsoft.Build.Execution;
 using NuGet.Build.Packaging.Properties;
 using Xunit;
@@ -133,6 +134,24 @@ namespace NuGet.Build.Packaging
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				PackagePath = @"contentFiles\any\monoandroid51\Resources\drawable-hdpi\Icon.png",
+			}));
+		}
+
+		[Fact]
+		public void content_no_copy_is_included_from_source()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_library_with_content), new
+			{
+				PackageId = "ContentPackage"
+			});
+
+			result.AssertSuccess(output);
+
+			var sourcePath = Path.Combine(Path.GetDirectoryName(result.ProjectOrSolutionFile), "content-with-kind.txt");
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				FullPath = sourcePath,
 			}));
 		}
 
@@ -492,6 +511,24 @@ namespace NuGet.Build.Packaging
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				PackagePath = @"build\none-with-kind.txt",
+			}));
+		}
+
+		[Fact]
+		public void none_with_kind_is_included_from_source()
+		{
+			var result = Builder.BuildScenario(nameof(given_a_library_with_content), new
+			{
+				PackageId = "ContentPackage"
+			});
+
+			result.AssertSuccess(output);
+
+			var sourcePath = Path.Combine(Path.GetDirectoryName(result.ProjectOrSolutionFile), "none-with-kind.txt");
+
+			Assert.Contains(result.Items, item => item.Matches(new
+			{
+				FullPath = sourcePath,
 			}));
 		}
 


### PR DESCRIPTION
In this case, the package files should be referenced from their source path, not the outputpath-relative location.

This was not working if the CopyToOutput was because we were only considering '' to mean "not copying", but 'Never' is also a valid value for the same situation.