### PR TITLE
Implement workaround for 15.3 missing prerequisite installation

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.targets
@@ -2,5 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<AutoUnify>true</AutoUnify>
+		<ExtensionInstallationFolder>NuGetizer</ExtensionInstallationFolder>
 	</PropertyGroup>
 </Project>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
 		<Description xml:space="preserve">NuGet Package Authoring Tools</Description>
 		<License>LICENSE.txt</License>
 	</Metadata>
-	<Installation>
+	<Installation AllUsers="true">
 		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
 	</Installation>
 	<Prerequisites>


### PR DESCRIPTION
It's been confirmed that there is an issue where the prerequisites are not
installed automatically. This may be fixed by 15.3 RTW, but an official
workaround is to make the extension All Users (require Admin).

We take the chance to also install to a nice well-known location :)

Fixes https://github.com/NuGet/Home/issues/5383