### PR TITLE
Coalesce duplicate FrameworkReferences when preparing package manifest.

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -179,13 +179,13 @@ namespace NuGet.Build.Packaging.Tasks
 
 		void AddFrameworkAssemblies(Manifest manifest)
 		{
-			var frameworkReferences = from item in Contents
-									  where item.GetMetadata(MetadataName.Kind) == PackageItemKind.FrameworkReference
-									  select new FrameworkAssemblyReference
-									  (
-										  item.ItemSpec,
-										  new [] { NuGetFramework.Parse(item.GetTargetFrameworkMoniker().FullName) }
-									  );
+			var frameworkReferences = (from item in Contents
+			 						   where item.GetMetadata(MetadataName.Kind) == PackageItemKind.FrameworkReference
+			 						   select new FrameworkAssemblyReference
+									   (
+										   item.ItemSpec,
+										   new[] { NuGetFramework.Parse(item.GetTargetFrameworkMoniker().FullName) }
+									   )).Distinct(FrameworkAssemblyReferenceComparer.Default);
 
 			manifest.Metadata.FrameworkReferences = frameworkReferences;
 		}

--- a/src/Build/NuGet.Build.Packaging.Tasks/FrameworkAssemblyReferenceComparer.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/FrameworkAssemblyReferenceComparer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging;
 
-namespace NuGet.Build.Packaging
+namespace NuGet.Build.Packaging.Tasks
 {
 	public class FrameworkAssemblyReferenceComparer : IEqualityComparer<FrameworkAssemblyReference>
     {

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -544,5 +544,49 @@ namespace NuGet.Build.Packaging
 
 			Assert.NotNull(manifest);
 		}
+
+		[Fact]
+		public void when_creating_package_with_duplicate_framework_references_then_contains_only_unique_references()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
+				}),
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
+				}),
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+				}),
+				new TaskItem("System.Xml", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.Equal(manifest.Metadata.FrameworkReferences,
+				new[]
+				{
+					new FrameworkAssemblyReference("System.Xml", new [] { NuGetFramework.Parse(TargetFrameworks.NET45) }),
+					new FrameworkAssemblyReference("System.Xml", new [] { NuGetFramework.Parse(TargetFrameworks.PCL78) }),
+				},
+				FrameworkAssemblyReferenceComparer.Default);
+
+			Assert.NotNull(manifest);
+		}
 	}
 }


### PR DESCRIPTION
Adds test for duplicate framework references when creating packages and code to coalesce duplicate framework references when generating the package manifest. Moves FrameworkReferenceAssemblyComparer from Tests assembly to Tasks assembly.

Should fix NuGet/Home#5469

This corrects the problem by catching duplicate framework references when generating the manifest. If you'd prefer to filter duplicates when merging MSBuild Items then a different approach would be required and the included test will not work.  