### PR TITLE
Add the prerequisite Merq component explicitly

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="GitInfo" Version="1.1.61" />
     <PackageReference Include="Merq" Version="1.0.0-rc" />
     <PackageReference Include="Merq.Async" Version="1.1.17-rc" />
-    <PackageReference Include="Merq.VisualStudio" Version="1.1.17-rc" />
     <PackageReference Include="Microsoft.Build" Version="15.1.548" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.0.751" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" />

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
 	<Metadata>
-		<Identity Id="NuGet.Packaging" Version="|NuGet.Packaging.VisualStudio.15;GetVersion|" Language="en-US" Publisher="Microsoft" />
+		<Identity Id="NuGet.Packaging" Version="|NuGet.Packaging.VisualStudio.15;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
 		<DisplayName>NuGetizer-3000</DisplayName>
 		<Description xml:space="preserve">NuGet Package Authoring Tools</Description>
 		<License>LICENSE.txt</License>
@@ -11,6 +11,7 @@
 	</Installation>
 	<Prerequisites>
 		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.Merq" DisplayName="Extensibility Message Bus" Version="[1.1.17,)" />
 	</Prerequisites>
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Packaging.VisualStudio" Path="|NuGet.Packaging.VisualStudio|"/>

--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.Shared.targets
@@ -43,12 +43,12 @@
 
 	<Target Name="EnsureNuGetizerPackage"
 			Condition="'$(CreateVsixContainer)' != 'false' And '$(DeployExtension)' != 'false'"
-			DependsOnTargets="GetVersion" 
+			DependsOnTargets="GetPackageVersion;GetVsixVersion" 
 			BeforeTargets="DeployVsixExtensionFiles;CreateVsixContainer">
 		<ItemGroup>
 			<_NuGetizerPackage Include="$(Out)\*.nupkg" />
 			<_CurrentNuGetizerPackage Include="@(_NuGetizerPackage)"
-									  Condition="$([System.String]::New('%(Filename)').Replace('NuGet.Build.Packaging.', '')) == '$(Version)'" />
+									  Condition="$([System.String]::New('%(Filename)').Replace('NuGet.Build.Packaging.', '')) == '$(PackageVersion)'" />
 		</ItemGroup>
 
 		<PropertyGroup>
@@ -66,9 +66,9 @@
   Packages found were: %0a@(_NuGetizerPackage -> '    %(Filename)%(Extension)', '%0a')" />
 	</Target>
 
-	<Target Name="GetVersion" DependsOnTargets="GitVersion" Returns="$(Version)">
+	<Target Name="GetVsixVersion" DependsOnTargets="GitVersion" Returns="$(VsixVersion)">
 		<PropertyGroup>
-			<Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</Version>
+			<VsixVersion>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</VsixVersion>
 		</PropertyGroup>
 	</Target>
 
@@ -105,7 +105,7 @@
 				 Value="$(PackageVersion)"/>
 	</Target>
 
-	<Target Name="CopyVsixToOut" AfterTargets="CreateVsixContainer" DependsOnTargets="GetVersion"
+	<Target Name="CopyVsixToOut" AfterTargets="CreateVsixContainer" DependsOnTargets="GetVsixVersion"
 			Condition="'$(Out)' != '' And '$(CreateVsixContainer)' == 'true' And Exists('$(TargetVsixContainer)')">
 		<ItemGroup>
 			<TargetVsixContainer Include="$(TargetVsixContainer)" />
@@ -113,7 +113,7 @@
 		<!-- Copy the evergreen filename -->
 		<Copy SourceFiles="@(TargetVsixContainer)" DestinationFolder="$(Out)" />
 		<!-- And also a versioned filename -->
-		<Copy SourceFiles="@(TargetVsixContainer)" DestinationFiles="$(Out)\%(TargetVsixContainer.Filename).$(Version)%(TargetVsixContainer.Extension)" />
+		<Copy SourceFiles="@(TargetVsixContainer)" DestinationFiles="$(Out)\%(TargetVsixContainer.Filename).$(VsixVersion)%(TargetVsixContainer.Extension)" />
 	</Target>
 
 	<!-- Because envdte comes from a nuget package, we can't set the EmbedInteropTypes to true in the project, so we do it here -->


### PR DESCRIPTION
The existing implicit prerequisite insertion from Merq nuget package isn't working
as expected because the component ID in VS doesn't match the generated JSON file name,
so instead of relying on the Merq.VisualStudio nuget package to inject the prerequisite,
we just add it ourselves manually.

Also fixed versioning of the nuget package for local builds with the new numbering scheme.

Fixes #5383