### PR TITLE
Force build order of UpdateTargetPath.

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Authoring.targets
@@ -64,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 	<!-- Just to make it easy for consumers to request the TargetPath as usual but get the 
 		 actual package file, which contains the PackageVersion and will be dynamic therefore. -->
 	<Target Name="UpdateTargetPath"
-			BeforeTargets="GetTargetPath"
+			BeforeTargets="GetTargetPath;GetTargetPathWithTargetPlatformMoniker"
 			DependsOnTargets="GetPackageTargetPath">
 		<PropertyGroup>
 			<TargetPath>@(PackageTargetPath->'%(FullPath)')</TargetPath>


### PR DESCRIPTION
Make UpdateTargetPath target run before GetTargetPath AND GetTargetPathWithTargetPlatformMoniker.

Modified UpdateTargetPath to include both GetTargetPath and GetTargetPathWithTargetPlatformMoniker in its BeforeTargets attribute. 

Corrects NuGet/Home#5821