### PR TITLE
If debug symbols are produced at all, default to always including them

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Inference.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Inference.targets
@@ -27,7 +27,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 		<!-- Whether to include @(BuiltProjectOutputGroupOutput), @(DocumentationProjectOutputGroupOutput) and @(SatelliteDllsProjectOutputGroupOutput) items in the package -->
 		<IncludeOutputsInPackage Condition="'$(IncludeOutputsInPackage)' == ''">true</IncludeOutputsInPackage>
 		<!-- Whether to include @(DebugSymbolsProjectOutputGroupOutput) items in the package -->
-		<IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == '' and '$(IncludeOutputsInPackage)' == 'true' and '$(Configuration)' == 'Debug'">true</IncludeSymbolsInPackage>
+		<IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == '' and '$(IncludeOutputsInPackage)' == 'true'">true</IncludeSymbolsInPackage>
 		<!-- Whether to include framework references (%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}') in the package -->
 
 		<!-- Only default to true if the project isn't a nuget packaging project itself and its primary output is lib. -->


### PR DESCRIPTION
The default should not depend on the project configuration, and rather on the inclusion of
outputs instead. Whether or not there are symbols to include would by default depend on 
whether they were generated in the first place instead, which is a more sensible default.