### PR TITLE
Added baseNuspecFile support and removed duplicate files exception

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -158,7 +158,7 @@ namespace NuGet.Build.Packaging.Tasks
 
 		void AddFiles(Manifest manifest)
 		{
-			// Remove duplcate files
+			// Remove duplicate files
 			var contents = Contents
 				.Where(item => !string.IsNullOrEmpty(item.GetMetadata(MetadataName.PackagePath)))
 				.GroupBy(item => item.GetMetadata(MetadataName.PackagePath))

--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -158,17 +158,11 @@ namespace NuGet.Build.Packaging.Tasks
 
 		void AddFiles(Manifest manifest)
 		{
-			var contents = Contents.Where(item =>
-				!string.IsNullOrEmpty(item.GetMetadata(MetadataName.PackagePath)));
-
-			var duplicates = contents.GroupBy(item => item.GetMetadata(MetadataName.PackagePath))
-				.Where(x => x.Count() > 1)
-				.Select(x => x.Key);
-
-			foreach (var duplicate in duplicates)
-			{
-				Log.LogErrorCode(nameof(ErrorCode.NG0012), ErrorCode.NG0012(duplicate));
-			}
+			// Remove duplcate files
+			var contents = Contents
+				.Where(item => !string.IsNullOrEmpty(item.GetMetadata(MetadataName.PackagePath)))
+				.GroupBy(item => item.GetMetadata(MetadataName.PackagePath))
+				.Select(x => x.First());
 
 			// All files need to be added so they are included in the nupkg
 			manifest.Files.AddRange(contents

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -233,7 +233,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 	<Target Name="_GetReferencedPackageContents"
 			Condition="'$(_SupportsProjectReferences)' == 'true'"
-			DependsOnTargets="$(_GetReferencedPackageContentsDependsOn)" 
+			DependsOnTargets="$(_GetReferencedPackageContentsDependsOn)"
 			Returns="@(PackageFile)">
 		<Error Condition="'@(_NonNuGetizedProjectReference)' != ''"
 				   Code="NG0011"
@@ -374,7 +374,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 	-->
 	<Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Returns="@(PackageTargetPath)" Condition="'$(IsPackable)' == 'true'">
 		<MakeDir Directories="$(PackageOutputPath)" Condition="!Exists('$(PackageOutputPath)')" />
-		<CreatePackage Manifest="@(PackageTargetPath)" NuspecFile="$(NuspecFile)" Contents="@(_PackageContent)" TargetPath="@(PackageTargetPath->'%(FullPath)')">
+		<CreatePackage Manifest="@(PackageTargetPath)" NuspecFile="$(NuspecFile)" BaseNuspecFile="$(BaseNuspecFile)" Contents="@(_PackageContent)" TargetPath="@(PackageTargetPath->'%(FullPath)')">
 			<Output TaskParameter="OutputPackage" ItemName="_PackageTargetPath" />
 			<Output TaskParameter="OutputPackage" ItemName="FileWrites" />
 		</CreatePackage>


### PR DESCRIPTION
Added support to base the nuget package of an existing nuspec file. This was possible in the NuProj projects and I've duplicated the behavior. 

Also I've removed the duplicate file exception. The _PackageContent variable will contain duplicate file references when one or more project references the same files/assemblies, this should not cause an exception. Instead the duplicates are removed and the first reference is used.