### PR TITLE
Fixed targets not imported during multitargeting

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.Tasks.csproj
@@ -26,7 +26,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Update="NuGet.Build.Packaging.MultiTargeting.targets">
-      <PackagePath>buildMultiTargeting\%(Filename)%(Extension)</PackagePath>
+      <PackagePath>buildMultiTargeting\NuGet.Build.Packaging%(Extension)</PackagePath>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The `buildMultiTargeting\NuGet.Build.Packaging.MultiTargeting.targets` file was not imported into msbuild script during multi-target phase, due to the name not matching the package id.

Related to <https://github.com/NuGet/Home/issues/6277>

Changed `buildMultiTargeting\NuGet.Build.Packaging.MultiTargeting.targets`  
to  
`buildMultiTargeting\NuGet.Build.Packaging.targets`,  
removing the MultiTargeting part from the file name.

The issue is demonstrated and can be tested with the repo
<https://github.com/ChristophLindemann/NuGet.Build.Packaging.MultiTargeting.Test>

**This is only a partial fix!** The files are now correctly imported, but it fails with `error NG0012: Duplicate package source files with distinct content detected. Duplicates are not allowed in the package. Please remove the conflict between these files...` due to package content from referenced multitarget projects are imported multiple times.
I guess when resolving references, it should take into account the targetframework and only resolve those which are matching.

Maybe @kzu has some input on where/how to solve?

This problem can also be seen with the [NuGet.Build.Packaging.MultiTargeting.Test repo](https://github.com/ChristophLindemann/NuGet.Build.Packaging.MultiTargeting.Test) after upgrading to a new version of `NuGet.Build.Packaging` with the fixed buildMultiTargeting stuff.

