### PR TITLE
Bump problematic NuGet packages

### DIFF
--- a/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
+++ b/src/VisualStudio/NuGet.Packaging.VisualStudio.15/NuGet.Packaging.VisualStudio.15.csproj
@@ -58,8 +58,8 @@
     <PackageReference Include="MSBuilder.DumpItems" Version="0.2.1" />
     <PackageReference Include="MSBuilder.Introspect" Version="0.1.5" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" />
-    <PackageReference Include="MSBuilder.VsixDependency" Version="0.2.13" />
-    <PackageReference Include="MSBuilder.VsixInstaller" Version="0.2.18" />
+    <PackageReference Include="MSBuilder.VsixDependency" Version="0.2.16" />
+    <PackageReference Include="MSBuilder.VsixInstaller" Version="1.0.7" />
     <PackageReference Include="VSLangProj150" Version="1.0.0" />
     <PackageReference Include="VSSDK.ComponentModelHost.11" Version="11.0.4" />
   </ItemGroup>


### PR DESCRIPTION
On my machine, the old versions caused strange errors, complaining of non-overridden abstract methods (at least, I think; the error was less than clear).