### PR TITLE
ApiIntersect - Ignore unresolved assemblies by default

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/ApiIntersect.cs
@@ -27,6 +27,8 @@ namespace NuGet.Build.Packaging.Tasks
 
 		public string KeepMarshalling { get; set; }
 
+		public string IgnoreUnresolvedAssemblies { get; set; }
+
 		[Required]
 		public ITaskItem RootOutputDirectory { get; set; }
 
@@ -99,6 +101,8 @@ namespace NuGet.Build.Packaging.Tasks
 			AppendSwitchIfTrue(builder, "-k", KeepInternalConstructors);
 
 			AppendSwitchIfTrue(builder, "-m", KeepMarshalling);
+
+			AppendSwitchIfTrue(builder, "-iua", IgnoreUnresolvedAssemblies);
 
 			return builder.ToString();
 		}

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.ReferenceAssembly.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.ReferenceAssembly.targets
@@ -62,6 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 		<PropertyGroup>
 			<EnableDefaultIntersectionAssemblyReferencePath Condition="'$(EnableDefaultIntersectionAssemblyReferencePath)' == ''">true</EnableDefaultIntersectionAssemblyReferencePath>
+			<IntersectionIgnoreUnresolvedAssemblies Condition="'$(IntersectionIgnoreUnresolvedAssemblies)' == ''">true</IntersectionIgnoreUnresolvedAssemblies>
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -79,6 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				ExcludeAssembly="@(IntersectionExcludeAssembly)"
 				KeepInternalConstructors="$(IntersectionKeepInternalConstructors)"
 				KeepMarshalling="$(IntersectionKeepMarshalling)"
+				IgnoreUnresolvedAssemblies="$(IntersectionIgnoreUnresolvedAssemblies)"
 				ToolPath="$(ApiIntersectToolPath)"
 				ToolExe="$(ApiIntersectToolExe)">
 			<Output TaskParameter="OutputDirectory" ItemName="_ReferenceAssemblyBuildInfo" />


### PR DESCRIPTION
Running ApiIntersect on an Android project will fail to resolve the
MonoAndroid assembly. Since this assembly is not required and should
not be included in the generated classes a new argument has been
added to the ApiIntersect tool so unresolved assemblies can be
ignored and the classes can be generated without an exception
being thrown. This prevents the ApiIntersect.exe error on building:

```
NuGet.Build.Packaging.ReferenceAssembly.targets(3,3):
Error MSB6006: "ApiIntersect.exe" exited with code 1. (MSB6006)
```

With verbose msbuild logging the ApiIntersect crash is:
```
  Unhandled Exception:
  System.Exception: Could not resolve Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065
    at ApiIntersect.FrameworkAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name, Mono.Cecil.ReaderParameters parameters) [0x0001b] in <aac3e0d5bcd4473a96e385115da49b96>:0
    at ApiIntersect.FrameworkAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name) [0x00000] in <aac3e0d5bcd4473a96e385115da49b96>:0
    at ICSharpCode.Decompiler.Ast.Transforms.IntroduceUsingDeclarations.Run (ICSharpCode.NRefactory.CSharp.AstNode compilationUnit) [0x00142] in <37b5ad8a7a94479fbc5b574a8fc6281a>:0
    at ICSharpCode.Decompiler.Ast.Transforms.TransformationPipeline.RunTransformationsUntil (ICSharpCode.NRefactory.CSharp.AstNode node, System.Predicate`1[T] abortCondition, ICSharpCode.Decompiler.DecompilerContext context) [0x0002c] in <37b5ad8a7a94479fbc5b574a8fc6281a>:0
    at ICSharpCode.Decompiler.Ast.AstBuilder.RunTransformations (System.Predicate`1[T] transformAbortCondition) [0x00000] in <37b5ad8a7a94479fbc5b574a8fc6281a>:0
    at ICSharpCode.Decompiler.Ast.AstBuilder.RunTransformations () [0x00000] in <37b5ad8a7a94479fbc5b574a8fc6281a>:0
    at ApiIntersect.MainClass.DumpTypes (System.Collections.Generic.List`1[T] types, System.String baseDir) [0x000a7] in <aac3e0d5bcd4473a96e385115da49b96>:0
    at ApiIntersect.MainClass.Process (System.Collections.Generic.List`1[T] intersections, System.Collections.Generic.List`1[T] exclusions, Mono.Cecil.ReaderParameters readerParameters, System.String outputPath) [0x00319] in <aac3e0d5bcd4473a96e385115da49b96>:0
    at ApiIntersect.MainClass.Main (System.String[] args) [0x0039f] in <aac3e0d5bcd4473a96e385115da49b96>:0
```

Note that the missing assembly references will be reported by MSBuild as warnings so this information is not hidden from the user.
