### PR TITLE
Opt-in to transitive content flow

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -114,7 +114,8 @@ namespace NuGet.Build.Packaging.Tasks
 								   Id = item.ItemSpec,
 								   Version = VersionRange.Parse(item.GetMetadata(MetadataName.Version)),
 								   TargetFramework = item.GetNuGetTargetFramework(),
-								   Include = item.GetNullableMetadata(MetadataName.IncludeAssets)
+								   Include = item.GetNullableMetadata(MetadataName.IncludeAssets),
+								   Exclude = item.GetNullableMetadata(MetadataName.ExcludeAssets)
 							   };
 
 			var definedDependencyGroups = (from dependency in dependencies
@@ -130,7 +131,7 @@ namespace NuGet.Build.Packaging.Tasks
 													 dependenciesById.Key,
 													 dependenciesById.Select(x => x.Version).Aggregate(AggregateVersions),
 													 dependenciesById.Select(x => x.Include).Aggregate(default(List<string>), AggregateIncludes),
-													 null
+													 dependenciesById.Select(x => x.Exclude).Aggregate(default(List<string>), AggregateIncludes)
 												 )).ToList()
 										   )).ToDictionary(p => p.TargetFramework.GetFrameworkString());
 
@@ -350,6 +351,8 @@ namespace NuGet.Build.Packaging.Tasks
 			public VersionRange Version { get; set; }
 
 			public string Include { get; set; }
+
+			public string Exclude { get; set; }
 		}
 
 		class VersionSpec

--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -130,8 +130,8 @@ namespace NuGet.Build.Packaging.Tasks
 												 (
 													 dependenciesById.Key,
 													 dependenciesById.Select(x => x.Version).Aggregate(AggregateVersions),
-													 dependenciesById.Select(x => x.Include).Aggregate(default(List<string>), AggregateIncludes),
-													 dependenciesById.Select(x => x.Exclude).Aggregate(default(List<string>), AggregateIncludes)
+													 dependenciesById.Select(x => x.Include).Aggregate(default(List<string>), AggregateAssetsFlow),
+													 dependenciesById.Select(x => x.Exclude).Aggregate(default(List<string>), AggregateAssetsFlow)
 												 )).ToList()
 										   )).ToDictionary(p => p.TargetFramework.GetFrameworkString());
 
@@ -289,7 +289,7 @@ namespace NuGet.Build.Packaging.Tasks
 			return versionSpec.ToVersionRange();
 		}
 
-		static List<string> AggregateIncludes(List<string> aggregate, string next)
+		static List<string> AggregateAssetsFlow(List<string> aggregate, string next)
 		{
 			if (next == null)
 				return aggregate;

--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -113,7 +113,8 @@ namespace NuGet.Build.Packaging.Tasks
 							   {
 								   Id = item.ItemSpec,
 								   Version = VersionRange.Parse(item.GetMetadata(MetadataName.Version)),
-								   TargetFramework = item.GetNuGetTargetFramework()
+								   TargetFramework = item.GetNuGetTargetFramework(),
+								   Include = item.GetMetadata(MetadataName.IncludeAssets)
 							   };
 
 			var definedDependencyGroups = (from dependency in dependencies
@@ -127,8 +128,9 @@ namespace NuGet.Build.Packaging.Tasks
 												select new PackageDependency
 												 (
 													 dependenciesById.Key,
-													 dependenciesById.Select(x => x.Version)
-													 .Aggregate(AggregateVersions)
+													 dependenciesById.Select(x => x.Version).Aggregate(AggregateVersions),
+													 dependenciesById.SelectMany(x => x.Include.Split(';')).Distinct().ToList(),
+													 null
 												 )).ToList()
 										   )).ToDictionary(p => p.TargetFramework.GetFrameworkString());
 
@@ -336,6 +338,8 @@ namespace NuGet.Build.Packaging.Tasks
 			public NuGetFramework TargetFramework { get; set; }
 
 			public VersionRange Version { get; set; }
+
+			public string Include { get; set; }
 		}
 
 		class VersionSpec

--- a/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
@@ -30,6 +30,8 @@
 		/// </summary>
 		public const string PrivateAssets = nameof(PrivateAssets);
 
+		public const string IncludeAssets = nameof(IncludeAssets);
+
 		/// <summary>
 		/// Whether the project can be packed as a .nupkg.
 		/// </summary>

--- a/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/MetadataName.cs
@@ -32,6 +32,8 @@
 
 		public const string IncludeAssets = nameof(IncludeAssets);
 
+		public const string ExcludeAssets = nameof(ExcludeAssets);
+
 		/// <summary>
 		/// Whether the project can be packed as a .nupkg.
 		/// </summary>

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -176,6 +176,32 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
+		public void when_creating_package_with_dependency_and_exclude_assets_then_contains_dependency_exclude_attribute()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" },
+					{ MetadataName.ExcludeAssets, "all" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.First().Exclude.Count);
+			Assert.Equal("all", manifest.Metadata.DependencyGroups.First().Packages.First().Exclude[0]);
+		}
+
+		[Fact]
 		public void when_creating_package_with_dependency_and_without_include_assets_then_not_contains_dependency_include_attribute()
 		{
 			task.Contents = new[]
@@ -197,6 +223,30 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
 			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
 			Assert.Equal(0, manifest.Metadata.DependencyGroups.First().Packages.First().Include.Count);
+		}
+
+		[Fact]
+		public void when_creating_package_with_dependency_and_without_exclude_assets_then_not_contains_dependency_exclude_attribute()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+			Assert.Equal(0, manifest.Metadata.DependencyGroups.First().Packages.First().Exclude.Count);
 		}
 
 		[Fact]

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -150,6 +150,56 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
+		public void when_creating_package_with_dependency_and_include_assets_then_contains_dependency_include_attribute()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" },
+					{ MetadataName.IncludeAssets, "all" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.First().Include.Count);
+			Assert.Equal("all", manifest.Metadata.DependencyGroups.First().Packages.First().Include[0]);
+		}
+
+		[Fact]
+		public void when_creating_package_with_dependency_and_without_include_assets_then_not_contains_dependency_include_attribute()
+		{
+			task.Contents = new[]
+			{
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var manifest = ExecuteTask();
+
+			Assert.NotNull(manifest);
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.Count());
+			Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.Count());
+			Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+			Assert.Equal(0, manifest.Metadata.DependencyGroups.First().Packages.First().Include.Count);
+		}
+
+		[Fact]
 		public void when_creating_package_with_non_framework_secific_dependency_then_contains_generic_dependency_group()
 		{
 			task.Contents = new[]


### PR DESCRIPTION
This PR enables the control of the ``Include`` attribute for a ``dependency`` with the ``IncludeAssets`` metadata. See https://github.com/NuGet/Home/wiki/%5BSpec%5D-Managing-dependency-package-assets#nuspec for details.

Consider ProjectA with
``
<ProjectReference Include="ProjectB" IncludeAssets="all" />
``
will result in a ProjectA.nuspec with
``
<dependency id="ProjectB" include="all" />
``
which when ProjectA.nuspec gets referenced will also pull in the content of ProjectB into the root project.