### PR TITLE
Rearrange project file imports

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -71,4 +71,6 @@ AssemblyVersion=$(AssemblyVersion)" />
 		<Copy SourceFiles="$(PackageTargetPath)" DestinationFolder="$(TEMP)\packages" />
 	</Target>
 
+	<Import Project="$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets" Condition="Exists('$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets')" />
+
 </Project>

--- a/src/NuGet.Build.Packaging.Shared.targets
+++ b/src/NuGet.Build.Packaging.Shared.targets
@@ -7,8 +7,6 @@
 		<ThisAssemblyProjectProperty Include="PackageVersion" />
 	</ItemGroup>
 
-	<Import Project="$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets" Condition="Exists('$(MSBuildProjectDirectory)\$(MSBuildProjectName).targets')" />
-
 	<PropertyGroup>
 		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 		<NuGetPackagingTargetsImported>true</NuGetPackagingTargetsImported>


### PR DESCRIPTION
This changes fixes an issue where the PackOnBuild property is not
respected, because the BuildDependsOn property is set too soon, and
is then overwritten with the default values in MSBuild. This only
affects projects build as part of this solution.