### PR TITLE
Support PackageType metadata

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
+++ b/src/Build/NuGet.Build.Packaging.Tasks/CreatePackage.cs
@@ -94,6 +94,7 @@ namespace NuGet.Build.Packaging.Tasks
 			metadata.ReleaseNotes = Manifest.GetMetadata("ReleaseNotes");
 			metadata.Tags = Manifest.GetMetadata("Tags");
 			metadata.MinClientVersionString = Manifest.GetMetadata("MinClientVersion");
+			metadata.PackageTypes = ParsePackageTypes(Manifest.GetMetadata("PackageTypes"));
 
 			var manifest = new Manifest(metadata);
 
@@ -341,6 +342,26 @@ namespace NuGet.Build.Packaging.Tasks
 				target.IsMaxInclusive = target.IsMaxInclusive && source.IsMaxInclusive;
 		}
 
+		static ICollection<PackageType> ParsePackageTypes(string packageTypes)
+		{
+			var listOfPackageTypes = new List<PackageType>();
+			if (!string.IsNullOrEmpty(packageTypes))
+			{
+				foreach (var packageType in packageTypes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+				{
+					string[] packageTypeSplitInPart = packageType.Split(new char[] { ',' });
+					string packageTypeName = packageTypeSplitInPart[0].Trim();
+					var version = PackageType.EmptyVersion;
+					if (packageTypeSplitInPart.Length > 1)
+					{
+						string versionString = packageTypeSplitInPart[1];
+						Version.TryParse(versionString, out version);
+					}
+					listOfPackageTypes.Add(new PackageType(packageTypeName, version));
+				}
+			}
+			return listOfPackageTypes;
+		}
 
 		class Dependency
 		{

--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -136,7 +136,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				<ReleaseNotes>$(PackageReleaseNotes)</ReleaseNotes>
 				<RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
 				<RepositoryType>$(RepositoryType)</RepositoryType>
-				<PackageTypes>$(PackageTypes)</PackageTypes>
+				<PackageTypes>$(PackageType)</PackageTypes>
 			</PackageTargetPath>
 		</ItemGroup>
 	</Target>

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -703,9 +703,11 @@ namespace NuGet.Build.Packaging
 			task.Manifest = new TaskItem("package",
 				new Metadata
 				{
-					{"Id", "package"},
-					{"Version", "1.0.0"},
-					{"Title", "title"},
+					{ "Id", "package" },
+					{ "Version", "1.0.0" },
+					{ "Title", "title" },
+					{ "Description", "description" },
+					{ "Authors", "author1, author2" },
 				});
 
 			task.Contents = new[]
@@ -730,10 +732,12 @@ namespace NuGet.Build.Packaging
 			task.Manifest = new TaskItem("package",
 				new Metadata
 				{
-					{"Id", "package"},
-					{"Version", "1.0.0"},
-					{"Title", "title"},
-					{"PackageTypes", string.Empty }
+					{ "Id", "package" },
+					{ "Version", "1.0.0" },
+					{ "Title", "title" },
+					{ "Description", "description" },
+					{ "Authors", "author1, author2" },
+					{ "PackageTypes", string.Empty }
 				});
 
 			task.Contents = new[]
@@ -758,10 +762,12 @@ namespace NuGet.Build.Packaging
 			task.Manifest = new TaskItem("package",
 				new Metadata
 				{
-					{"Id", "package"},
-					{"Version", "1.0.0"},
-					{"Title", "title"},
-					{"PackageTypes", "SomeType, 2.0.0" }
+					{ "Id", "package" },
+					{ "Version", "1.0.0" },
+					{ "Title", "title" },
+					{ "Description", "description" },
+					{ "Authors", "author1, author2" },
+					{ "PackageTypes", "SomeType, 2.0.0" }
 				});
 
 			task.Contents = new[]
@@ -786,15 +792,17 @@ namespace NuGet.Build.Packaging
 		}
 
 		[Fact]
-		public void when_creating_package_with_multiple_package_typea()
+		public void when_creating_package_with_multiple_package_types()
 		{
 			task.Manifest = new TaskItem("package",
 				new Metadata
 				{
-					{"Id", "package"},
-					{"Version", "1.0.0"},
-					{"Title", "title"},
-					{"PackageTypes", "SomeType, 2.0.0; AnotherType; ThirdTypeWithVersion, 1.2.3.4" }
+					{ "Id", "package" },
+					{ "Version", "1.0.0" },
+					{ "Title", "title" },
+					{ "Description", "description" },
+					{ "Authors", "author1, author2" },
+					{ "PackageTypes", "SomeType, 2.0.0; AnotherType; ThirdTypeWithVersion, 1.2.3.4" }
 				});
 
 			task.Contents = new[]

--- a/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
+++ b/src/Build/NuGet.Build.Packaging.Tests/CreatePackageTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Evaluation;
@@ -53,6 +54,7 @@ namespace NuGet.Build.Packaging
 					{ "IconUrl", "http://contoso.com/icon.png" },
 					{ "ReleaseNotes", "release notes" },
 					{ "MinClientVersion", "3.4.0" },
+					{ "PackageTypes", PackageType.Dependency.Name }
 				})
 			};
 
@@ -98,6 +100,12 @@ namespace NuGet.Build.Packaging
 			Assert.Equal(task.Manifest.GetMetadata("IconUrl"), metadata.IconUrl.ToString());
 			Assert.Equal(task.Manifest.GetMetadata("ReleaseNotes"), metadata.ReleaseNotes);
 			Assert.Equal(task.Manifest.GetMetadata("MinClientVersion"), metadata.MinClientVersion.ToString());
+			Assert.Collection(metadata.PackageTypes,
+				item =>
+				{
+					Assert.Equal(PackageType.Dependency.Name, item.Name);
+					Assert.Equal(PackageType.EmptyVersion, item.Version);
+				});
 		}
 
 		[Fact]
@@ -687,6 +695,137 @@ namespace NuGet.Build.Packaging
 				FrameworkAssemblyReferenceComparer.Default);
 
 			Assert.NotNull(manifest);
+		}
+
+		[Fact]
+		public void when_creating_package_without_package_type()
+		{
+			task.Manifest = new TaskItem("package",
+				new Metadata
+				{
+					{"Id", "package"},
+					{"Version", "1.0.0"},
+					{"Title", "title"},
+				});
+
+			task.Contents = new[]
+			{
+				// Need at least one dependency or content file for the generation to succeed.
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var metadata = ExecuteTask().Metadata;
+			Assert.Empty(metadata.PackageTypes);
+		}
+
+		[Fact]
+		public void when_creating_package_with_package_type_empty()
+		{
+			task.Manifest = new TaskItem("package",
+				new Metadata
+				{
+					{"Id", "package"},
+					{"Version", "1.0.0"},
+					{"Title", "title"},
+					{"PackageTypes", string.Empty }
+				});
+
+			task.Contents = new[]
+			{
+				// Need at least one dependency or content file for the generation to succeed.
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var metadata = ExecuteTask().Metadata;
+			Assert.Empty(metadata.PackageTypes);
+		}
+
+		[Fact]
+		public void when_creating_package_with_package_type_version()
+		{
+			task.Manifest = new TaskItem("package",
+				new Metadata
+				{
+					{"Id", "package"},
+					{"Version", "1.0.0"},
+					{"Title", "title"},
+					{"PackageTypes", "SomeType, 2.0.0" }
+				});
+
+			task.Contents = new[]
+			{
+				// Need at least one dependency or content file for the generation to succeed.
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var metadata = ExecuteTask().Metadata;
+			Assert.Collection(metadata.PackageTypes,
+				item =>
+				{
+					Assert.Equal("SomeType", item.Name);
+					Assert.Equal(new Version(2, 0, 0), item.Version);
+				});
+		}
+
+		[Fact]
+		public void when_creating_package_with_multiple_package_typea()
+		{
+			task.Manifest = new TaskItem("package",
+				new Metadata
+				{
+					{"Id", "package"},
+					{"Version", "1.0.0"},
+					{"Title", "title"},
+					{"PackageTypes", "SomeType, 2.0.0; AnotherType; ThirdTypeWithVersion, 1.2.3.4" }
+				});
+
+			task.Contents = new[]
+			{
+				// Need at least one dependency or content file for the generation to succeed.
+				new TaskItem("Newtonsoft.Json", new Metadata
+				{
+					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.Version, "8.0.0" },
+					{ MetadataName.TargetFramework, "net45" }
+				}),
+			};
+
+			var metadata = ExecuteTask().Metadata;
+			Assert.Collection(metadata.PackageTypes,
+				item =>
+				{
+					Assert.Equal("SomeType", item.Name);
+					Assert.Equal(new Version(2, 0, 0), item.Version);
+				},
+				item =>
+				{
+					Assert.Equal("AnotherType", item.Name);
+					Assert.Equal(PackageType.EmptyVersion, item.Version);
+				},
+				item =>
+				{
+					Assert.Equal("ThirdTypeWithVersion", item.Name);
+					Assert.Equal(new Version(1, 2, 3, 4), item.Version);
+				});
 		}
 	}
 }


### PR DESCRIPTION
Implements NuGet/Home#7250
Package type metadata should have same format, as documented at
https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target
Example:
```xml
<PackageType>DotNetCliTool, 1.0.0.0;Dependency, 2.0.0.0</PackageType>
```

ParsePackageTypes function was taken (and modified) from https://github.com/NuGet/NuGet.Client/blob/9fe40c06ab14f77848dd8ebe3a8e5cdc912cf0e3/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs#L339