### PR TITLE
Add workaround for Xamarin.Android 9.4

### DIFF
--- a/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
+++ b/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets
@@ -245,10 +245,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 			current project.
 		-->
 
+		<!--
+			Workaround for Xamarin.Android 9.4 requires DesignTimeBuild to be set for its FilterAssemblies target
+		-->
 		<MSBuild Projects="@(_NuGetizedProjectReference)"
 					 Targets="GetPackageContents"
 					 BuildInParallel="$(BuildInParallel)"
-					 Properties="%(_NuGetizedProjectReference.SetConfiguration); %(_NuGetizedProjectReference.SetPlatform); BuildingPackage=$(BuildingPackage)"
+					 Properties="%(_NuGetizedProjectReference.SetConfiguration); %(_NuGetizedProjectReference.SetPlatform); BuildingPackage=$(BuildingPackage); DesignTimeBuild=false"
 					 Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
 					 RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">
 			<Output TaskParameter="TargetOutputs" ItemName="_ReferencedPackageContent" />


### PR DESCRIPTION
When building a .nuproj project that referenced a Xamarin.Android
project _GetReferencedPackageContents would fail when
Xamarin.Android 9.4 was installed with the error:

    The "FilterAssemblies" task was not given a value for the required
    parameter "DesignTimeBuild".

To workaround this the DesignTimeBuild property is set, if not already,
and passed to the GetPackageContents.