### PR TITLE
Remove obsolete NuGet package source

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -3,7 +3,7 @@
 	<packageSources>
 		<clear />
 		<add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-		<add key="NuGetVolatile" value="https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json" />
+		<add key="NuGetVolatile" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
 	</packageSources>
 	<disabledPackageSources>
 		<clear />


### PR DESCRIPTION
MyGet NuGet package source is obsolete. Replacing with new package
source.